### PR TITLE
Add resilient native media downloads and release 0.1.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,28 @@ jobs:
           ## What's Changed
           HEREDOC
           echo "$CHANGES" >> RELEASE_NOTES.md
+          cat >> RELEASE_NOTES.md << 'HEREDOC'
+
+          ## Android downloader licensing
+
+          WaveFunc source remains MIT licensed. The Android APK also contains
+          youtubedl-android 0.18.1 under GPL-3.0. Its exact upstream source and
+          GPL license are attached to this release; WaveFunc corresponding
+          source is the source archive for this release tag.
+          HEREDOC
+
+      - name: Prepare Android GPL source and license
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            https://github.com/yausername/youtubedl-android/archive/refs/tags/0.18.1.tar.gz \
+            --output youtubedl-android-0.18.1-source.tar.gz
+          echo "08833449d671142c34325203cbfcca31c4fa668a0c4b8c0c31a2e4354ce11b98  youtubedl-android-0.18.1-source.tar.gz" | sha256sum --check
+          curl --fail --location --retry 3 \
+            https://raw.githubusercontent.com/yausername/youtubedl-android/0.18.1/LICENSE \
+            --output GPL-3.0-youtubedl-android.txt
+          echo "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986  GPL-3.0-youtubedl-android.txt" | sha256sum --check
 
       - name: Create GitHub Release
         id: create
@@ -51,6 +73,9 @@ jobs:
           body_path: RELEASE_NOTES.md
           draft: true
           prerelease: false
+          files: |
+            youtubedl-android-0.18.1-source.tar.gz
+            GPL-3.0-youtubedl-android.txt
 
   build-desktop:
     needs: create-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,55 @@ jobs:
       - name: Install frontend dependencies
         run: bun install
 
+      - name: Prepare desktop media engine (macOS)
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p src-tauri/resources/bin /tmp/wavefunc-deno-arm /tmp/wavefunc-deno-x64
+          curl --fail --location --retry 3 \
+            https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos \
+            --output src-tauri/resources/bin/yt-dlp
+          curl --fail --location --retry 3 \
+            https://github.com/denoland/deno/releases/download/v2.8.1/deno-aarch64-apple-darwin.zip \
+            --output /tmp/deno-arm.zip
+          curl --fail --location --retry 3 \
+            https://github.com/denoland/deno/releases/download/v2.8.1/deno-x86_64-apple-darwin.zip \
+            --output /tmp/deno-x64.zip
+          unzip -q /tmp/deno-arm.zip -d /tmp/wavefunc-deno-arm
+          unzip -q /tmp/deno-x64.zip -d /tmp/wavefunc-deno-x64
+          mv /tmp/wavefunc-deno-arm/deno src-tauri/resources/bin/deno-aarch64
+          mv /tmp/wavefunc-deno-x64/deno src-tauri/resources/bin/deno-x86_64
+          chmod +x src-tauri/resources/bin/yt-dlp \
+            src-tauri/resources/bin/deno-aarch64 \
+            src-tauri/resources/bin/deno-x86_64
+
+      - name: Prepare desktop media engine (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p src-tauri/resources/bin /tmp/wavefunc-deno
+          curl --fail --location --retry 3 \
+            https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux \
+            --output src-tauri/resources/bin/yt-dlp
+          curl --fail --location --retry 3 \
+            https://github.com/denoland/deno/releases/download/v2.8.1/deno-x86_64-unknown-linux-gnu.zip \
+            --output /tmp/deno.zip
+          unzip -q /tmp/deno.zip -d /tmp/wavefunc-deno
+          mv /tmp/wavefunc-deno/deno src-tauri/resources/bin/deno
+          chmod +x src-tauri/resources/bin/yt-dlp src-tauri/resources/bin/deno
+
+      - name: Prepare desktop media engine (Windows)
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force src-tauri/resources/bin | Out-Null
+          Invoke-WebRequest https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe -OutFile src-tauri/resources/bin/yt-dlp.exe
+          Invoke-WebRequest https://github.com/denoland/deno/releases/download/v2.8.1/deno-x86_64-pc-windows-msvc.zip -OutFile $env:RUNNER_TEMP/deno.zip
+          Expand-Archive -Force $env:RUNNER_TEMP/deno.zip $env:RUNNER_TEMP/wavefunc-deno
+          Move-Item $env:RUNNER_TEMP/wavefunc-deno/deno.exe src-tauri/resources/bin/deno.exe
+
       - name: Build frontend
         run: bun run build
 

--- a/docs/NATIVE_MEDIA_DOWNLOADS.md
+++ b/docs/NATIVE_MEDIA_DOWNLOADS.md
@@ -1,0 +1,42 @@
+# Native media downloads
+
+WaveFunc acquires YouTube media only in installed Android and desktop apps. The
+website keeps search and preview support, but directs users to `/apps` for a
+reliable local download.
+
+## Flow
+
+1. The native engine validates the video ID and downloads on the user's device.
+   The app assigns the job ID up front and polls queryable native job state, so a
+   completed download can be recovered if Android backgrounds the WebView and
+   drops the original command response.
+2. It streams the file through SHA-256 without loading the full file into memory.
+3. The user's signer creates a short-lived Blossom BUD-11 authorization scoped
+   to the exact hash and lowercase Blossom domain. The UI shows this as a
+   separate approval phase and fails with an actionable error after 90 seconds
+   instead of leaving stale download output on screen indefinitely.
+4. The native engine streams the file to `PUT /upload` with `X-SHA-256` and a
+   Base64url (unpadded) Nostr authorization header.
+5. Temporary files are removed after success, error, cancellation, or the
+   Android foreground-service timeout.
+
+The Android transfer service remains in the foreground across download,
+external signing, and upload so the WebView may be backgrounded safely.
+
+## Release inputs
+
+Desktop release jobs download and bundle the current official `yt-dlp` binary
+and Deno 2.8.1. Deno is passed explicitly as yt-dlp's JavaScript challenge
+runtime. Development builds may set `WAVEFUNC_YTDLP_PATH` and
+`WAVEFUNC_DENO_PATH`.
+
+Android uses `io.github.junkfood02.youtubedl-android` 0.18.1, which embeds
+yt-dlp, Python, QuickJS, and ffmpeg.
+
+## Android licensing release gate
+
+`youtubedl-android` is GPL-3.0 licensed. Before publishing an APK containing
+this dependency, confirm the distribution approach, notices, corresponding
+source availability, and compatibility with WaveFunc's current MIT licensing.
+This implementation is suitable for development testing, but Android release
+must not be treated as license-cleared merely because it builds successfully.

--- a/docs/NATIVE_MEDIA_DOWNLOADS.md
+++ b/docs/NATIVE_MEDIA_DOWNLOADS.md
@@ -33,10 +33,14 @@ runtime. Development builds may set `WAVEFUNC_YTDLP_PATH` and
 Android uses `io.github.junkfood02.youtubedl-android` 0.18.1, which embeds
 yt-dlp, Python, QuickJS, and ffmpeg.
 
-## Android licensing release gate
+## Android licensing distribution
 
-`youtubedl-android` is GPL-3.0 licensed. Before publishing an APK containing
-this dependency, confirm the distribution approach, notices, corresponding
-source availability, and compatibility with WaveFunc's current MIT licensing.
-This implementation is suitable for development testing, but Android release
-must not be treated as license-cleared merely because it builds successfully.
+WaveFunc source remains MIT licensed. The Android APK also contains
+`youtubedl-android` 0.18.1 under GPL-3.0. The APK packages that dependency's
+license text, while the release workflow attaches its checksum-pinned upstream
+source archive and license alongside the APK. The WaveFunc source archive for
+the exact release tag supplies the corresponding application source and build
+scripts.
+
+These release inputs must be updated and reviewed whenever the Android
+downloader version changes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-react-template",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "wavefunc"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2297,6 +2297,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,6 +3202,7 @@ dependencies = [
  "cookie_store",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3213,12 +3224,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -3253,7 +3266,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4219,6 +4232,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-wavefunc-media"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "hex",
+ "mime_guess",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "tauri-plugin-wavefunc-player"
 version = "0.1.0"
 dependencies = [
@@ -4464,6 +4497,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4793,6 +4827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4982,6 +5022,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -5008,6 +5061,7 @@ dependencies = [
  "tauri-plugin-http",
  "tauri-plugin-opener",
  "tauri-plugin-os",
+ "tauri-plugin-wavefunc-media",
  "tauri-plugin-wavefunc-player",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-http = "2.5.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-wavefunc-player = { path = "plugins/native-player" }
+tauri-plugin-wavefunc-media = { path = "plugins/media-acquisition" }
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-cli = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavefunc"
-version = "0.1.5"
+version = "0.1.6"
 description = "Decentralized Radio Platform"
 authors = ["Schlaus Kwab"]
 license = "MIT"

--- a/src-tauri/android-template/MainActivity.kt
+++ b/src-tauri/android-template/MainActivity.kt
@@ -1,0 +1,39 @@
+package live.wavefunc.app
+
+import android.os.Bundle
+import android.view.View
+import androidx.activity.enableEdgeToEdge
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+class MainActivity : TauriActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
+    super.onCreate(savedInstanceState)
+
+    // A WebView does not expose CSS safe-area insets consistently on older
+    // Android versions. Apply the native system-bar and cutout insets to its
+    // root instead so fixed player controls remain tappable in both gesture
+    // and three-button navigation modes.
+    val content = findViewById<View>(android.R.id.content)
+    val initialLeft = content.paddingLeft
+    val initialTop = content.paddingTop
+    val initialRight = content.paddingRight
+    val initialBottom = content.paddingBottom
+
+    ViewCompat.setOnApplyWindowInsetsListener(content) { view, windowInsets ->
+      val safeInsets = windowInsets.getInsets(
+        WindowInsetsCompat.Type.systemBars() or
+          WindowInsetsCompat.Type.displayCutout()
+      )
+      view.setPadding(
+        initialLeft + safeInsets.left,
+        initialTop + safeInsets.top,
+        initialRight + safeInsets.right,
+        initialBottom + safeInsets.bottom,
+      )
+      WindowInsetsCompat.CONSUMED
+    }
+    ViewCompat.requestApplyInsets(content)
+  }
+}

--- a/src-tauri/android-template/build.gradle.kts
+++ b/src-tauri/android-template/build.gradle.kts
@@ -24,6 +24,11 @@ if (keystorePropertiesFile.exists()) {
 android {
     compileSdk = 36
     namespace = "live.wavefunc.app"
+    packaging {
+        // youtubedl-android loads its embedded Python/QuickJS archives from
+        // applicationInfo.nativeLibraryDir and therefore requires extraction.
+        jniLibs.useLegacyPackaging = true
+    }
     defaultConfig {
         // WaveFunc is a radio directory and many legitimate community
         // stations only expose an HTTP stream. The native player validates
@@ -107,8 +112,14 @@ val syncWavefuncIcons by tasks.registering(Copy::class) {
     into(layout.projectDirectory.dir("src/main/res"))
 }
 
+val syncWavefuncMainActivity by tasks.registering(Copy::class) {
+    from(file("../../../android-template/MainActivity.kt"))
+    into(layout.projectDirectory.dir("src/main/java/live/wavefunc/app"))
+}
+
 tasks.named("preBuild") {
     dependsOn(syncWavefuncIcons)
+    dependsOn(syncWavefuncMainActivity)
 }
 
 dependencies {

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
       ]
     },
     "deep-link:default",
-    "wavefunc-player:default"
+    "wavefunc-player:default",
+    "wavefunc-media:default"
   ]
 }

--- a/src-tauri/plugins/media-acquisition/.gitignore
+++ b/src-tauri/plugins/media-acquisition/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target/

--- a/src-tauri/plugins/media-acquisition/Cargo.toml
+++ b/src-tauri/plugins/media-acquisition/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tauri-plugin-wavefunc-media"
+version = "0.1.0"
+authors = ["WaveFunc"]
+description = "Local media acquisition and Blossom upload for WaveFunc"
+edition = "2021"
+rust-version = "1.77.2"
+links = "tauri-plugin-wavefunc-media"
+
+[dependencies]
+base64 = "0.22"
+hex = "0.4"
+mime_guess = "2"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+tauri = { version = "2" }
+thiserror = "2"
+tokio = { version = "1", features = ["fs", "io-util", "process", "sync"] }
+tokio-util = { version = "0.7", features = ["io"] }
+url = "2"
+uuid = { version = "1", features = ["v4"] }
+
+[build-dependencies]
+tauri-plugin = { version = "2", features = ["build"] }

--- a/src-tauri/plugins/media-acquisition/android/.gitignore
+++ b/src-tauri/plugins/media-acquisition/android/.gitignore
@@ -1,0 +1,3 @@
+/.gradle
+/.tauri
+/build

--- a/src-tauri/plugins/media-acquisition/android/build.gradle.kts
+++ b/src-tauri/plugins/media-acquisition/android/build.gradle.kts
@@ -1,0 +1,95 @@
+import java.net.URI
+import java.security.MessageDigest
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+// youtubedl-android 0.18.1 ships yt-dlp 2025.11.12, which YouTube now
+// rejects with HTTP 403 for some otherwise public media URLs. Override only
+// the zipapp resource with a current, checksum-pinned upstream stable build;
+// the Android/Python/ffmpeg wrapper remains supplied by the Maven dependency.
+val bundledYtDlpVersion = "2026.07.04"
+val bundledYtDlpSha256 = "495be29ff4d9d4e9be7eabdfef225221e5d5282e77f2f505abc6dca80349f3fd"
+val bundledYtDlpResDir = layout.buildDirectory.dir("generated/wavefunc-ytdlp/res")
+val bundledYtDlpFile = bundledYtDlpResDir.map { it.file("raw/ytdlp") }
+
+fun File.sha256(): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    inputStream().buffered().use { input ->
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            digest.update(buffer, 0, read)
+        }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
+}
+
+val prepareBundledYtDlp by tasks.registering {
+    outputs.file(bundledYtDlpFile)
+
+    doLast {
+        val output = bundledYtDlpFile.get().asFile
+        if (output.isFile && output.sha256() == bundledYtDlpSha256) return@doLast
+
+        output.parentFile.mkdirs()
+        val temporary = output.resolveSibling("${output.name}.download")
+        URI(
+            "https://github.com/yt-dlp/yt-dlp/releases/download/" +
+                "$bundledYtDlpVersion/yt-dlp",
+        ).toURL().openStream().buffered().use { input ->
+            temporary.outputStream().buffered().use { target -> input.copyTo(target) }
+        }
+
+        val actualHash = temporary.sha256()
+        check(actualHash == bundledYtDlpSha256) {
+            "yt-dlp $bundledYtDlpVersion checksum mismatch: $actualHash"
+        }
+        temporary.copyTo(output, overwrite = true)
+        check(temporary.delete()) { "Could not remove temporary yt-dlp download." }
+    }
+}
+
+android {
+    namespace = "live.wavefunc.media"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 24
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    sourceSets.named("main") {
+        res.srcDir(bundledYtDlpResDir)
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+dependencies {
+    implementation(project(":tauri-android"))
+    implementation("androidx.core:core-ktx:1.17.0")
+
+    // Embeds yt-dlp, Python, QuickJS and ffmpeg for local Android downloads.
+    // youtubedl-android is GPL-3.0; release compliance is documented alongside
+    // the native media engine and must be reviewed before shipping.
+    implementation("io.github.junkfood02.youtubedl-android:library:0.18.1")
+    implementation("io.github.junkfood02.youtubedl-android:ffmpeg:0.18.1")
+}
+
+tasks.named("preBuild") {
+    dependsOn(prepareBundledYtDlp)
+}

--- a/src-tauri/plugins/media-acquisition/android/build.gradle.kts
+++ b/src-tauri/plugins/media-acquisition/android/build.gradle.kts
@@ -15,6 +15,13 @@ val bundledYtDlpVersion = "2026.07.04"
 val bundledYtDlpSha256 = "495be29ff4d9d4e9be7eabdfef225221e5d5282e77f2f505abc6dca80349f3fd"
 val bundledYtDlpResDir = layout.buildDirectory.dir("generated/wavefunc-ytdlp/res")
 val bundledYtDlpFile = bundledYtDlpResDir.map { it.file("raw/ytdlp") }
+val youtubedlAndroidLicenseSha256 =
+    "3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986"
+val generatedLicenseAssetsDir =
+    layout.buildDirectory.dir("generated/wavefunc-licenses/assets")
+val youtubedlAndroidLicenseFile = generatedLicenseAssetsDir.map {
+    it.file("licenses/GPL-3.0-youtubedl-android.txt")
+}
 
 fun File.sha256(): String {
     val digest = MessageDigest.getInstance("SHA-256")
@@ -54,6 +61,32 @@ val prepareBundledYtDlp by tasks.registering {
     }
 }
 
+val prepareYoutubedlAndroidLicense by tasks.registering {
+    outputs.file(youtubedlAndroidLicenseFile)
+
+    doLast {
+        val output = youtubedlAndroidLicenseFile.get().asFile
+        if (output.isFile && output.sha256() == youtubedlAndroidLicenseSha256) {
+            return@doLast
+        }
+
+        output.parentFile.mkdirs()
+        val temporary = output.resolveSibling("${output.name}.download")
+        URI(
+            "https://raw.githubusercontent.com/yausername/youtubedl-android/0.18.1/LICENSE",
+        ).toURL().openStream().buffered().use { input ->
+            temporary.outputStream().buffered().use { target -> input.copyTo(target) }
+        }
+
+        val actualHash = temporary.sha256()
+        check(actualHash == youtubedlAndroidLicenseSha256) {
+            "youtubedl-android license checksum mismatch: $actualHash"
+        }
+        temporary.copyTo(output, overwrite = true)
+        check(temporary.delete()) { "Could not remove temporary license download." }
+    }
+}
+
 android {
     namespace = "live.wavefunc.media"
     compileSdk = 36
@@ -70,6 +103,7 @@ android {
 
     sourceSets.named("main") {
         res.srcDir(bundledYtDlpResDir)
+        assets.srcDir(generatedLicenseAssetsDir)
     }
 }
 
@@ -84,12 +118,12 @@ dependencies {
     implementation("androidx.core:core-ktx:1.17.0")
 
     // Embeds yt-dlp, Python, QuickJS and ffmpeg for local Android downloads.
-    // youtubedl-android is GPL-3.0; release compliance is documented alongside
-    // the native media engine and must be reviewed before shipping.
+    // youtubedl-android is GPL-3.0. Its license is packaged in the APK and the
+    // release workflow publishes the matching upstream source archive.
     implementation("io.github.junkfood02.youtubedl-android:library:0.18.1")
     implementation("io.github.junkfood02.youtubedl-android:ffmpeg:0.18.1")
 }
 
 tasks.named("preBuild") {
-    dependsOn(prepareBundledYtDlp)
+    dependsOn(prepareBundledYtDlp, prepareYoutubedlAndroidLicense)
 }

--- a/src-tauri/plugins/media-acquisition/android/consumer-rules.pro
+++ b/src-tauri/plugins/media-acquisition/android/consumer-rules.pro
@@ -1,0 +1,1 @@
+# Consumer rules for the WaveFunc media plugin.

--- a/src-tauri/plugins/media-acquisition/android/proguard-rules.pro
+++ b/src-tauri/plugins/media-acquisition/android/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Project-specific rules for the WaveFunc media plugin.

--- a/src-tauri/plugins/media-acquisition/android/settings.gradle
+++ b/src-tauri/plugins/media-acquisition/android/settings.gradle
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "wavefunc-media"

--- a/src-tauri/plugins/media-acquisition/android/src/main/AndroidManifest.xml
+++ b/src-tauri/plugins/media-acquisition/android/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application android:extractNativeLibs="true">
+        <service
+            android:name="live.wavefunc.media.MediaDownloadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+    </application>
+</manifest>

--- a/src-tauri/plugins/media-acquisition/android/src/main/java/live/wavefunc/media/MediaDownloadService.kt
+++ b/src-tauri/plugins/media-acquisition/android/src/main/java/live/wavefunc/media/MediaDownloadService.kt
@@ -1,0 +1,66 @@
+package live.wavefunc.media
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.os.Handler
+import android.os.Looper
+import androidx.core.app.NotificationCompat
+
+/** Keeps Android from suspending the process during a user-requested transfer. */
+class MediaDownloadService : Service() {
+    private val handler = Handler(Looper.getMainLooper())
+    private val timeout = Runnable { stopSelf() }
+
+    override fun onCreate() {
+        super.onCreate()
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "Media downloads",
+                NotificationManager.IMPORTANCE_LOW,
+            ),
+        )
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(applicationInfo.icon)
+            .setContentTitle("WaveFunc")
+            .setContentText("Saving media to Blossom…")
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .apply {
+                if (launchIntent != null) {
+                    setContentIntent(
+                        android.app.PendingIntent.getActivity(
+                            this@MediaDownloadService,
+                            0,
+                            launchIntent,
+                            android.app.PendingIntent.FLAG_UPDATE_CURRENT or
+                                android.app.PendingIntent.FLAG_IMMUTABLE,
+                        ),
+                    )
+                }
+            }
+            .build()
+        startForeground(NOTIFICATION_ID, notification)
+        handler.postDelayed(timeout, MAX_LIFETIME_MS)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_NOT_STICKY
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        handler.removeCallbacks(timeout)
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "wavefunc_media_downloads"
+        private const val NOTIFICATION_ID = 7302
+        private const val MAX_LIFETIME_MS = 15 * 60 * 1000L
+    }
+}

--- a/src-tauri/plugins/media-acquisition/android/src/main/java/live/wavefunc/media/WavefuncMediaPlugin.kt
+++ b/src-tauri/plugins/media-acquisition/android/src/main/java/live/wavefunc/media/WavefuncMediaPlugin.kt
@@ -1,0 +1,460 @@
+package live.wavefunc.media
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Build
+import android.util.Base64
+import android.util.Log
+import android.webkit.MimeTypeMap
+import androidx.core.content.ContextCompat
+import app.tauri.annotation.Command
+import app.tauri.annotation.InvokeArg
+import app.tauri.annotation.TauriPlugin
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSObject
+import app.tauri.plugin.Plugin
+import com.yausername.ffmpeg.FFmpeg
+import com.yausername.youtubedl_android.YoutubeDL
+import com.yausername.youtubedl_android.YoutubeDLRequest
+import org.json.JSONObject
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URL
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+
+@InvokeArg
+class PrepareArgs {
+    lateinit var videoId: String
+    var format: String = "audio"
+    lateinit var jobId: String
+}
+
+@InvokeArg
+class UploadArgs {
+    lateinit var jobId: String
+    lateinit var blossomUrl: String
+    lateinit var signedAuthEvent: String
+}
+
+@InvokeArg
+class JobIdArgs {
+    lateinit var jobId: String
+}
+
+private data class MediaJob(
+    val directory: File,
+    val file: File,
+    val sha256: String,
+    val size: Long,
+    val mimeType: String,
+)
+
+@TauriPlugin
+class WavefuncMediaPlugin(private val activity: Activity) : Plugin(activity) {
+    private val executor = Executors.newSingleThreadExecutor()
+    private val jobs = ConcurrentHashMap<String, MediaJob>()
+    private val preparingJobs = ConcurrentHashMap.newKeySet<String>()
+    private val preparationErrors = ConcurrentHashMap<String, String>()
+    private var runtimeUpdateChecked = false
+
+    @Command
+    fun prepare(invoke: Invoke) {
+        val args = invoke.parseArgs(PrepareArgs::class.java)
+        if (!args.videoId.matches(Regex("^[A-Za-z0-9_-]{11}$"))) {
+            invoke.reject("Invalid YouTube video ID.")
+            return
+        }
+        if (args.format !in setOf("audio", "360p", "480p", "720p")) {
+            invoke.reject("Unsupported media format.")
+            return
+        }
+        if (!isValidJobId(args.jobId)) {
+            invoke.reject("Invalid media job ID.")
+            return
+        }
+        if (jobs.containsKey(args.jobId) || !preparingJobs.add(args.jobId)) {
+            invoke.reject("This media job is already running.")
+            return
+        }
+
+        startTransferService()
+        executor.execute {
+            val jobId = args.jobId
+            val directory = File(activity.cacheDir, "media-jobs/$jobId")
+            var keepAliveForUpload = false
+            try {
+                directory.mkdirs()
+                YoutubeDL.init(activity.applicationContext)
+                FFmpeg.init(activity.applicationContext)
+                val refreshedBeforeDownload = refreshYtDlpIfNeeded()
+
+                fun executeDownload() {
+                    val request = YoutubeDLRequest(
+                        "https://www.youtube.com/watch?v=${args.videoId}",
+                    ).apply {
+                        addOption("--no-playlist")
+                        addOption("--no-warnings")
+                        addOption("--newline")
+                        addOption("--output", File(directory, "media.%(ext)s").absolutePath)
+                        addOption("--format", formatSelector(args.format))
+                    }
+
+                    YoutubeDL.execute(request, jobId) { progress, _, text ->
+                        val event = JSObject()
+                        event.put("stage", "downloading")
+                        event.put("progress", progress.toDouble())
+                        event.put("message", text.trim().take(240))
+                        trigger("progress", event)
+                    }
+                }
+
+                try {
+                    executeDownload()
+                } catch (error: Exception) {
+                    // yt-dlp playback URLs can stop working independently of
+                    // metadata extraction. If our daily update check was
+                    // skipped, a 403 gets one forced refresh and one retry.
+                    if (
+                        !refreshedBeforeDownload &&
+                        isForbiddenMediaError(error) &&
+                        refreshYtDlpIfNeeded(force = true)
+                    ) {
+                        directory.listFiles()?.forEach { it.deleteRecursively() }
+                        executeDownload()
+                    } else {
+                        throw error
+                    }
+                }
+
+                val output = directory.listFiles()?.firstOrNull {
+                    it.isFile && !it.name.endsWith(".part") && !it.name.endsWith(".ytdl")
+                } ?: throw IllegalStateException("The local media engine produced no output file.")
+                val hash = sha256(output)
+                val mimeType = mimeType(output)
+                val job = MediaJob(directory, output, hash, output.length(), mimeType)
+                jobs[jobId] = job
+                preparationErrors.remove(jobId)
+
+                val response = preparedMediaResponse(jobId, job)
+                // Keep the foreground service alive while the user approves
+                // the short-lived Blossom token in an external signer.
+                keepAliveForUpload = true
+                invoke.resolve(response)
+            } catch (error: Exception) {
+                Log.e(TAG, "Local media preparation failed", error)
+                directory.deleteRecursively()
+                val message = usefulMessage(error, "Local media download failed")
+                preparationErrors[jobId] = message
+                invoke.reject(message)
+            } finally {
+                preparingJobs.remove(jobId)
+                if (!keepAliveForUpload) stopTransferService()
+            }
+        }
+    }
+
+    @Command
+    fun status(invoke: Invoke) {
+        val args = invoke.parseArgs(JobIdArgs::class.java)
+        if (!isValidJobId(args.jobId)) {
+            invoke.reject("Invalid media job ID.")
+            return
+        }
+
+        val response = JSObject()
+        val job = jobs[args.jobId]
+        val error = preparationErrors[args.jobId]
+        when {
+            job != null -> {
+                response.put("state", "prepared")
+                response.put("media", preparedMediaResponse(args.jobId, job))
+            }
+            error != null -> {
+                response.put("state", "failed")
+                response.put("error", error)
+            }
+            preparingJobs.contains(args.jobId) -> response.put("state", "preparing")
+            else -> response.put("state", "missing")
+        }
+        invoke.resolve(response)
+    }
+
+    @Command
+    fun upload(invoke: Invoke) {
+        val args = invoke.parseArgs(UploadArgs::class.java)
+        val job = jobs[args.jobId]
+        if (job == null || !job.file.isFile) {
+            invoke.reject("Local media file was not found. Download it again.")
+            return
+        }
+
+        val uploadUrl = try {
+            blossomUploadUrl(args.blossomUrl)
+        } catch (error: Exception) {
+            invoke.reject(error.message ?: "Invalid Blossom server.")
+            return
+        }
+        try {
+            validateAuthEvent(args.signedAuthEvent, job.sha256, uploadUrl.host)
+        } catch (error: Exception) {
+            invoke.reject(error.message ?: "Invalid Blossom authorization.")
+            return
+        }
+
+        startTransferService()
+        executor.execute {
+            var connection: HttpURLConnection? = null
+            try {
+                connection = uploadUrl.openConnection() as HttpURLConnection
+                connection.requestMethod = "PUT"
+                connection.doOutput = true
+                connection.connectTimeout = 20_000
+                connection.readTimeout = 60_000
+                connection.setFixedLengthStreamingMode(job.size)
+                connection.setRequestProperty("Content-Type", job.mimeType)
+                connection.setRequestProperty("Content-Length", job.size.toString())
+                connection.setRequestProperty("X-SHA-256", job.sha256)
+                val auth = Base64.encodeToString(
+                    args.signedAuthEvent.toByteArray(Charsets.UTF_8),
+                    Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING,
+                )
+                connection.setRequestProperty("Authorization", "Nostr $auth")
+
+                job.file.inputStream().buffered().use { input ->
+                    connection.outputStream.buffered().use { output ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        var uploaded = 0L
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            output.write(buffer, 0, read)
+                            uploaded += read
+                            val event = JSObject()
+                            event.put("stage", "uploading")
+                            event.put("progress", (uploaded * 100.0 / job.size).coerceIn(0.0, 100.0))
+                            event.put("message", "Uploading to Blossom…")
+                            trigger("progress", event)
+                        }
+                    }
+                }
+
+                val status = connection.responseCode
+                val responseBody = (if (status in 200..299) {
+                    connection.inputStream
+                } else {
+                    connection.errorStream
+                })?.bufferedReader()?.use { it.readText() }.orEmpty()
+                if (status !in 200..299) {
+                    throw IllegalStateException(
+                        "Blossom upload failed ($status): ${responseBody.take(300)}",
+                    )
+                }
+
+                val blob = JSONObject(responseBody)
+                val response = JSObject()
+                response.put("url", blob.getString("url"))
+                response.put("sha256", blob.optString("sha256", job.sha256))
+                response.put("size", blob.optLong("size", job.size))
+                response.put("mimeType", job.mimeType)
+                invoke.resolve(response)
+            } catch (error: Exception) {
+                Log.e(TAG, "Blossom upload failed", error)
+                invoke.reject(usefulMessage(error, "Blossom upload failed"))
+            } finally {
+                connection?.disconnect()
+                cleanup(args.jobId)
+                stopTransferService()
+            }
+        }
+    }
+
+    @Command
+    fun discard(invoke: Invoke) {
+        val args = invoke.parseArgs(JobIdArgs::class.java)
+        cleanup(args.jobId)
+        stopTransferService()
+        invoke.resolve()
+    }
+
+    @Command
+    fun cancel(invoke: Invoke) {
+        val args = invoke.parseArgs(JobIdArgs::class.java)
+        YoutubeDL.destroyProcessById(args.jobId)
+        cleanup(args.jobId)
+        stopTransferService()
+        invoke.resolve()
+    }
+
+    private fun cleanup(jobId: String) {
+        preparationErrors.remove(jobId)
+        preparingJobs.remove(jobId)
+        val job = jobs.remove(jobId)
+        (job?.directory ?: File(activity.cacheDir, "media-jobs/$jobId")).deleteRecursively()
+    }
+
+    private fun preparedMediaResponse(jobId: String, job: MediaJob): JSObject = JSObject().apply {
+        put("jobId", jobId)
+        put("sha256", job.sha256)
+        put("size", job.size)
+        put("mimeType", job.mimeType)
+    }
+
+    private fun isValidJobId(jobId: String): Boolean =
+        jobId.length in 8..80 && jobId.all { it.isLetterOrDigit() || it == '-' || it == '_' }
+
+    private fun formatSelector(format: String): String = when (format) {
+        "audio" -> "bestaudio[ext=m4a]/bestaudio"
+        "360p" -> videoFormatSelector(360)
+        "480p" -> videoFormatSelector(480)
+        "720p" -> videoFormatSelector(720)
+        else -> throw IllegalArgumentException("Unsupported media format.")
+    }
+
+    private fun videoFormatSelector(height: Int): String =
+        "bestvideo[height<=$height][ext=mp4]+bestaudio[ext=m4a]/" +
+            "bestvideo[height<=$height]+bestaudio/" +
+            "best[height<=$height]/bestvideo+bestaudio/best"
+
+    /**
+     * Keep the extractor current without making GitHub availability a hard
+     * dependency. The APK carries a checksum-pinned stable fallback; this
+     * daily check lets installed apps survive future YouTube player changes.
+     */
+    private fun refreshYtDlpIfNeeded(force: Boolean = false): Boolean {
+        if (runtimeUpdateChecked) return false
+
+        val preferences = activity.getSharedPreferences(RUNTIME_PREFS, Activity.MODE_PRIVATE)
+        val now = System.currentTimeMillis()
+        val lastCheck = preferences.getLong(LAST_RUNTIME_UPDATE_CHECK, 0L)
+        if (!force && now - lastCheck < RUNTIME_UPDATE_INTERVAL_MS) return false
+
+        runtimeUpdateChecked = true
+        val event = JSObject()
+        event.put("stage", "preparing")
+        event.put("message", "Checking the local media engine…")
+        trigger("progress", event)
+
+        return try {
+            val previousVersion = YoutubeDL.versionName(activity.applicationContext)
+            val status = YoutubeDL.updateYoutubeDL(
+                activity.applicationContext,
+                YoutubeDL.UpdateChannel.STABLE,
+            )
+            preferences.edit().putLong(LAST_RUNTIME_UPDATE_CHECK, now).apply()
+            Log.i(
+                TAG,
+                "yt-dlp update check: $status ($previousVersion -> " +
+                    "${YoutubeDL.versionName(activity.applicationContext)})",
+            )
+            true
+        } catch (error: Exception) {
+            // Downloads can still work with the pinned APK copy while offline
+            // or when GitHub is temporarily unreachable.
+            Log.w(TAG, "Could not refresh yt-dlp; using bundled runtime", error)
+            false
+        }
+    }
+
+    private fun isForbiddenMediaError(error: Exception): Boolean =
+        generateSequence<Throwable>(error) { it.cause }
+            .mapNotNull { it.message }
+            .any { message -> message.contains("HTTP Error 403") }
+
+    private fun blossomUploadUrl(raw: String): URL {
+        val uri = URI(raw.trim())
+        require(uri.scheme.equals("https", ignoreCase = true)) {
+            "Blossom uploads require an HTTPS server."
+        }
+        require(!uri.host.isNullOrBlank()) { "Invalid Blossom server." }
+        return URI(raw.trim().trimEnd('/') + "/upload").toURL()
+    }
+
+    private fun validateAuthEvent(raw: String, hash: String, server: String) {
+        val event = JSONObject(raw)
+        require(event.optInt("kind") == 24242) { "Invalid Blossom authorization kind." }
+        val tags = event.getJSONArray("tags")
+        fun hasTag(name: String, value: String): Boolean {
+            for (index in 0 until tags.length()) {
+                val tag = tags.optJSONArray(index) ?: continue
+                if (tag.optString(0) == name && tag.optString(1) == value) return true
+            }
+            return false
+        }
+        require(
+            hasTag("t", "upload") && hasTag("x", hash) && hasTag("server", server),
+        ) { "Blossom authorization does not match this file and server." }
+        val expiration = (0 until tags.length())
+            .mapNotNull { tags.optJSONArray(it) }
+            .firstOrNull { it.optString(0) == "expiration" }
+            ?.optLong(1, 0L)
+            ?: 0L
+        require(expiration > System.currentTimeMillis() / 1000L) {
+            "Blossom authorization has expired."
+        }
+        require(
+            event.optString("id").isNotBlank() &&
+                event.optString("pubkey").isNotBlank() &&
+                event.optString("sig").isNotBlank(),
+        ) { "The Blossom authorization was not signed." }
+    }
+
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().buffered().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun mimeType(file: File): String {
+        val extension = file.extension.lowercase()
+        return when (extension) {
+            "m4a" -> "audio/mp4"
+            "mp3" -> "audio/mpeg"
+            "webm", "weba" -> "video/webm"
+            "mp4" -> "video/mp4"
+            else -> MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+                ?: "application/octet-stream"
+        }
+    }
+
+    private fun usefulMessage(error: Exception, fallback: String): String {
+        val details = generateSequence<Throwable>(error) { it.cause }
+            .mapNotNull { it.message }
+            .flatMap { it.lineSequence() }
+            .filter { it.isNotBlank() }
+            .toList()
+            .takeLast(8)
+            .distinct()
+            .joinToString("\n")
+        return details.ifBlank { fallback }
+    }
+
+    private fun startTransferService() {
+        val intent = Intent(activity, MediaDownloadService::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            ContextCompat.startForegroundService(activity, intent)
+        } else {
+            activity.startService(intent)
+        }
+    }
+
+    private fun stopTransferService() {
+        activity.stopService(Intent(activity, MediaDownloadService::class.java))
+    }
+
+    companion object {
+        private const val TAG = "WavefuncMedia"
+        private const val RUNTIME_PREFS = "wavefunc_media_runtime"
+        private const val LAST_RUNTIME_UPDATE_CHECK = "last_update_check_ms"
+        private const val RUNTIME_UPDATE_INTERVAL_MS = 24L * 60L * 60L * 1000L
+    }
+}

--- a/src-tauri/plugins/media-acquisition/build.rs
+++ b/src-tauri/plugins/media-acquisition/build.rs
@@ -1,0 +1,15 @@
+const COMMANDS: &[&str] = &[
+    "prepare",
+    "status",
+    "upload",
+    "discard",
+    "cancel",
+    "register_listener",
+    "remove_listener",
+];
+
+fn main() {
+    tauri_plugin::Builder::new(COMMANDS)
+        .android_path("android")
+        .build();
+}

--- a/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/cancel.toml
+++ b/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/cancel.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-cancel"
+description = "Enables the cancel command without any pre-configured scope."
+commands.allow = ["cancel"]
+
+[[permission]]
+identifier = "deny-cancel"
+description = "Denies the cancel command without any pre-configured scope."
+commands.deny = ["cancel"]

--- a/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/discard.toml
+++ b/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/discard.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-discard"
+description = "Enables the discard command without any pre-configured scope."
+commands.allow = ["discard"]
+
+[[permission]]
+identifier = "deny-discard"
+description = "Denies the discard command without any pre-configured scope."
+commands.deny = ["discard"]

--- a/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/prepare.toml
+++ b/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/prepare.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-prepare"
+description = "Enables the prepare command without any pre-configured scope."
+commands.allow = ["prepare"]
+
+[[permission]]
+identifier = "deny-prepare"
+description = "Denies the prepare command without any pre-configured scope."
+commands.deny = ["prepare"]

--- a/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/register_listener.toml
+++ b/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/register_listener.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-register-listener"
+description = "Enables the register_listener command without any pre-configured scope."
+commands.allow = ["register_listener"]
+
+[[permission]]
+identifier = "deny-register-listener"
+description = "Denies the register_listener command without any pre-configured scope."
+commands.deny = ["register_listener"]

--- a/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/remove_listener.toml
+++ b/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/remove_listener.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-remove-listener"
+description = "Enables the remove_listener command without any pre-configured scope."
+commands.allow = ["remove_listener"]
+
+[[permission]]
+identifier = "deny-remove-listener"
+description = "Denies the remove_listener command without any pre-configured scope."
+commands.deny = ["remove_listener"]

--- a/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/status.toml
+++ b/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/status.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-status"
+description = "Enables the status command without any pre-configured scope."
+commands.allow = ["status"]
+
+[[permission]]
+identifier = "deny-status"
+description = "Denies the status command without any pre-configured scope."
+commands.deny = ["status"]

--- a/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/upload.toml
+++ b/src-tauri/plugins/media-acquisition/permissions/autogenerated/commands/upload.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-upload"
+description = "Enables the upload command without any pre-configured scope."
+commands.allow = ["upload"]
+
+[[permission]]
+identifier = "deny-upload"
+description = "Denies the upload command without any pre-configured scope."
+commands.deny = ["upload"]

--- a/src-tauri/plugins/media-acquisition/permissions/autogenerated/reference.md
+++ b/src-tauri/plugins/media-acquisition/permissions/autogenerated/reference.md
@@ -1,0 +1,205 @@
+## Default Permission
+
+Allow WaveFunc to acquire media locally and upload it to Blossom
+
+#### This default permission set includes the following:
+
+- `allow-prepare`
+- `allow-status`
+- `allow-upload`
+- `allow-discard`
+- `allow-cancel`
+- `allow-register-listener`
+- `allow-remove-listener`
+
+## Permission Table
+
+<table>
+<tr>
+<th>Identifier</th>
+<th>Description</th>
+</tr>
+
+
+<tr>
+<td>
+
+`wavefunc-media:allow-cancel`
+
+</td>
+<td>
+
+Enables the cancel command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:deny-cancel`
+
+</td>
+<td>
+
+Denies the cancel command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:allow-discard`
+
+</td>
+<td>
+
+Enables the discard command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:deny-discard`
+
+</td>
+<td>
+
+Denies the discard command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:allow-prepare`
+
+</td>
+<td>
+
+Enables the prepare command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:deny-prepare`
+
+</td>
+<td>
+
+Denies the prepare command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:allow-register-listener`
+
+</td>
+<td>
+
+Enables the register_listener command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:deny-register-listener`
+
+</td>
+<td>
+
+Denies the register_listener command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:allow-remove-listener`
+
+</td>
+<td>
+
+Enables the remove_listener command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:deny-remove-listener`
+
+</td>
+<td>
+
+Denies the remove_listener command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:allow-status`
+
+</td>
+<td>
+
+Enables the status command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:deny-status`
+
+</td>
+<td>
+
+Denies the status command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:allow-upload`
+
+</td>
+<td>
+
+Enables the upload command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`wavefunc-media:deny-upload`
+
+</td>
+<td>
+
+Denies the upload command without any pre-configured scope.
+
+</td>
+</tr>
+</table>

--- a/src-tauri/plugins/media-acquisition/permissions/default.toml
+++ b/src-tauri/plugins/media-acquisition/permissions/default.toml
@@ -1,0 +1,11 @@
+[default]
+description = "Allow WaveFunc to acquire media locally and upload it to Blossom"
+permissions = [
+  "allow-prepare",
+  "allow-status",
+  "allow-upload",
+  "allow-discard",
+  "allow-cancel",
+  "allow-register-listener",
+  "allow-remove-listener",
+]

--- a/src-tauri/plugins/media-acquisition/permissions/schemas/schema.json
+++ b/src-tauri/plugins/media-acquisition/permissions/schemas/schema.json
@@ -1,0 +1,390 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PermissionFile",
+  "description": "Permission file that can define a default permission, a set of permissions or a list of inlined permissions.",
+  "type": "object",
+  "properties": {
+    "default": {
+      "description": "The default permission set for the plugin",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultPermission"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
+    },
+    "permission": {
+      "description": "A list of inlined permissions",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Permission"
+      }
+    }
+  },
+  "definitions": {
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "platforms": {
+          "description": "Target platforms this permission applies. By default all platforms are affected by this permission.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "Commands": {
+      "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Allowed command.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "description": "Denied command, which takes priority.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "An argument for fine grained behavior control of Tauri commands.\n\nIt can be of any serde serializable type and is used to allow or prevent certain actions inside a Tauri command. The configured scope is passed to the command and will be enforced by the command implementation.\n\n## Example\n\n```json { \"allow\": [{ \"path\": \"$HOME/**\" }], \"deny\": [{ \"path\": \"$HOME/secret.txt\" }] } ```",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope. This should be prioritized by validation logic.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "Enables the cancel command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-cancel",
+          "markdownDescription": "Enables the cancel command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cancel command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-cancel",
+          "markdownDescription": "Denies the cancel command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the discard command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-discard",
+          "markdownDescription": "Enables the discard command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the discard command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-discard",
+          "markdownDescription": "Denies the discard command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the prepare command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-prepare",
+          "markdownDescription": "Enables the prepare command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the prepare command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-prepare",
+          "markdownDescription": "Denies the prepare command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-register-listener",
+          "markdownDescription": "Enables the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-register-listener",
+          "markdownDescription": "Denies the register_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-remove-listener",
+          "markdownDescription": "Enables the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-remove-listener",
+          "markdownDescription": "Denies the remove_listener command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the status command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-status",
+          "markdownDescription": "Enables the status command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the status command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-status",
+          "markdownDescription": "Denies the status command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the upload command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-upload",
+          "markdownDescription": "Enables the upload command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the upload command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-upload",
+          "markdownDescription": "Denies the upload command without any pre-configured scope."
+        },
+        {
+          "description": "Allow WaveFunc to acquire media locally and upload it to Blossom\n#### This default permission set includes:\n\n- `allow-prepare`\n- `allow-status`\n- `allow-upload`\n- `allow-discard`\n- `allow-cancel`\n- `allow-register-listener`\n- `allow-remove-listener`",
+          "type": "string",
+          "const": "default",
+          "markdownDescription": "Allow WaveFunc to acquire media locally and upload it to Blossom\n#### This default permission set includes:\n\n- `allow-prepare`\n- `allow-status`\n- `allow-upload`\n- `allow-discard`\n- `allow-cancel`\n- `allow-register-listener`\n- `allow-remove-listener`"
+        }
+      ]
+    }
+  }
+}

--- a/src-tauri/plugins/media-acquisition/src/commands.rs
+++ b/src-tauri/plugins/media-acquisition/src/commands.rs
@@ -1,0 +1,58 @@
+use tauri::{command, ipc::Channel, AppHandle, Runtime};
+
+use crate::{
+    PreparationStatus, PrepareRequest, PreparedMedia, Result, UploadRequest, UploadedMedia,
+    WavefuncMediaExt,
+};
+
+#[command]
+pub(crate) async fn prepare<R: Runtime>(
+    app: AppHandle<R>,
+    payload: PrepareRequest,
+) -> Result<PreparedMedia> {
+    app.wavefunc_media().prepare(payload).await
+}
+
+#[command]
+pub(crate) async fn status<R: Runtime>(
+    app: AppHandle<R>,
+    job_id: String,
+) -> Result<PreparationStatus> {
+    app.wavefunc_media().status(job_id).await
+}
+
+#[command]
+pub(crate) async fn upload<R: Runtime>(
+    app: AppHandle<R>,
+    payload: UploadRequest,
+) -> Result<UploadedMedia> {
+    app.wavefunc_media().upload(payload).await
+}
+
+#[command]
+pub(crate) async fn discard<R: Runtime>(app: AppHandle<R>, job_id: String) -> Result<()> {
+    app.wavefunc_media().discard(job_id).await
+}
+
+#[command]
+pub(crate) async fn cancel<R: Runtime>(app: AppHandle<R>, job_id: String) -> Result<()> {
+    app.wavefunc_media().cancel(job_id).await
+}
+
+#[command]
+pub(crate) async fn register_listener<R: Runtime>(
+    app: AppHandle<R>,
+    event: String,
+    handler: Channel<()>,
+) -> Result<()> {
+    app.wavefunc_media().register_listener(event, handler)
+}
+
+#[command]
+pub(crate) async fn remove_listener<R: Runtime>(
+    app: AppHandle<R>,
+    event: String,
+    channel_id: u32,
+) -> Result<()> {
+    app.wavefunc_media().remove_listener(event, channel_id)
+}

--- a/src-tauri/plugins/media-acquisition/src/desktop.rs
+++ b/src-tauri/plugins/media-acquisition/src/desktop.rs
@@ -1,0 +1,515 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::{Arc, Mutex},
+};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD as BASE64, Engine as _};
+use reqwest::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE};
+use serde::de::DeserializeOwned;
+use sha2::{Digest, Sha256};
+use tauri::{ipc::Channel, plugin::PluginApi, AppHandle, Manager, Runtime};
+use tokio::{fs, io::AsyncReadExt, process::Command};
+use tokio_util::io::ReaderStream;
+use url::Url;
+
+use crate::{
+    Error, MediaFormat, PreparationState, PreparationStatus, PrepareRequest, PreparedMedia, Result,
+    UploadRequest, UploadedMedia,
+};
+
+#[derive(Clone)]
+struct Job {
+    dir: PathBuf,
+    file: PathBuf,
+    sha256: String,
+    size: u64,
+    mime_type: String,
+}
+
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    app: &AppHandle<R>,
+    _api: PluginApi<R, C>,
+) -> Result<WavefuncMedia<R>> {
+    Ok(WavefuncMedia {
+        app: app.clone(),
+        jobs: Arc::new(Mutex::new(HashMap::new())),
+        preparations: Arc::new(Mutex::new(HashMap::new())),
+    })
+}
+
+pub struct WavefuncMedia<R: Runtime> {
+    app: AppHandle<R>,
+    jobs: Arc<Mutex<HashMap<String, Job>>>,
+    preparations: Arc<Mutex<HashMap<String, PreparationStatus>>>,
+}
+
+impl<R: Runtime> WavefuncMedia<R> {
+    pub async fn prepare(&self, payload: PrepareRequest) -> Result<PreparedMedia> {
+        validate_video_id(&payload.video_id)?;
+        validate_job_id(&payload.job_id)?;
+
+        let job_id = payload.job_id.clone();
+        self.preparations
+            .lock()
+            .map_err(|_| Error::Message("Media preparation store is unavailable.".into()))?
+            .insert(
+                job_id.clone(),
+                PreparationStatus {
+                    state: PreparationState::Preparing,
+                    media: None,
+                    error: None,
+                },
+            );
+        let cache_root = self
+            .app
+            .path()
+            .app_cache_dir()
+            .map_err(|error| Error::Message(error.to_string()))?
+            .join("media-jobs");
+        let dir = cache_root.join(&job_id);
+        fs::create_dir_all(&dir).await?;
+
+        let result = self.download(&payload, &dir).await;
+        let (file, sha256, size, mime_type) = match result {
+            Ok(result) => result,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&dir).await;
+                self.preparations
+                    .lock()
+                    .map_err(|_| Error::Message("Media preparation store is unavailable.".into()))?
+                    .insert(
+                        job_id,
+                        PreparationStatus {
+                            state: PreparationState::Failed,
+                            media: None,
+                            error: Some(error.to_string()),
+                        },
+                    );
+                return Err(error);
+            }
+        };
+
+        let job = Job {
+            dir,
+            file,
+            sha256: sha256.clone(),
+            size,
+            mime_type: mime_type.clone(),
+        };
+        self.jobs
+            .lock()
+            .map_err(|_| Error::Message("Media job store is unavailable.".into()))?
+            .insert(job_id.clone(), job);
+
+        let prepared = PreparedMedia {
+            job_id,
+            sha256,
+            size,
+            mime_type,
+        };
+        self.preparations
+            .lock()
+            .map_err(|_| Error::Message("Media preparation store is unavailable.".into()))?
+            .insert(
+                prepared.job_id.clone(),
+                PreparationStatus {
+                    state: PreparationState::Prepared,
+                    media: Some(prepared.clone()),
+                    error: None,
+                },
+            );
+        Ok(prepared)
+    }
+
+    pub async fn status(&self, job_id: String) -> Result<PreparationStatus> {
+        validate_job_id(&job_id)?;
+        Ok(self
+            .preparations
+            .lock()
+            .map_err(|_| Error::Message("Media preparation store is unavailable.".into()))?
+            .get(&job_id)
+            .cloned()
+            .unwrap_or(PreparationStatus {
+                state: PreparationState::Missing,
+                media: None,
+                error: None,
+            }))
+    }
+
+    async fn download(
+        &self,
+        payload: &PrepareRequest,
+        dir: &Path,
+    ) -> Result<(PathBuf, String, u64, String)> {
+        let binary = resolve_executable(
+            &self.app,
+            "WAVEFUNC_YTDLP_PATH",
+            if cfg!(windows) {
+                "yt-dlp.exe"
+            } else {
+                "yt-dlp"
+            },
+            Some(repo_development_binary("contextvm/bin/yt-dlp")),
+        )?;
+        let output_template = dir.join("media.%(ext)s");
+        let deno = resolve_executable(&self.app, "WAVEFUNC_DENO_PATH", bundled_deno_name(), None)?;
+        let video_url = format!("https://www.youtube.com/watch?v={}", payload.video_id);
+
+        let mut command = Command::new(binary);
+        command
+            .kill_on_drop(true)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .arg("--no-playlist")
+            .arg("--no-warnings")
+            .arg("--newline")
+            .arg("--js-runtimes")
+            .arg(format!("deno:{}", deno.display()))
+            .arg("--print")
+            .arg("after_move:filepath")
+            .arg("--output")
+            .arg(&output_template);
+
+        match payload.format {
+            MediaFormat::Audio => {
+                command.arg("--format").arg("bestaudio[ext=m4a]/bestaudio");
+            }
+            MediaFormat::P360 => {
+                command
+                    .arg("--format")
+                    .arg("bestvideo[height<=360][ext=mp4]+bestaudio[ext=m4a]/bestvideo[height<=360]+bestaudio/best[height<=360]/bestvideo+bestaudio/best");
+            }
+            MediaFormat::P480 => {
+                command
+                    .arg("--format")
+                    .arg("bestvideo[height<=480][ext=mp4]+bestaudio[ext=m4a]/bestvideo[height<=480]+bestaudio/best[height<=480]/bestvideo+bestaudio/best");
+            }
+            MediaFormat::P720 => {
+                command
+                    .arg("--format")
+                    .arg("bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/bestvideo[height<=720]+bestaudio/best[height<=720]/bestvideo+bestaudio/best");
+            }
+        }
+        command.arg(video_url);
+
+        let output = command.output().await.map_err(|error| {
+            Error::Message(format!("Could not start the local media engine: {error}"))
+        })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let detail = useful_error_tail(&stderr);
+            return Err(Error::Message(format!(
+                "Local media download failed: {detail}"
+            )));
+        }
+
+        let file = find_downloaded_file(dir).await?;
+        let metadata = fs::metadata(&file).await?;
+        let size = metadata.len();
+        let sha256 = hash_file(&file).await?;
+        let mime_type = mime_guess::from_path(&file)
+            .first_or_octet_stream()
+            .essence_str()
+            .to_owned();
+        Ok((file, sha256, size, mime_type))
+    }
+
+    pub async fn upload(&self, payload: UploadRequest) -> Result<UploadedMedia> {
+        let job = self
+            .jobs
+            .lock()
+            .map_err(|_| Error::Message("Media job store is unavailable.".into()))?
+            .get(&payload.job_id)
+            .cloned()
+            .ok_or_else(|| {
+                Error::Message("Local media file was not found. Download it again.".into())
+            })?;
+
+        let upload_url = blossom_upload_url(&payload.blossom_url)?;
+        validate_auth_event(
+            &payload.signed_auth_event,
+            &job.sha256,
+            upload_url.host_str().unwrap_or_default(),
+        )?;
+
+        let file = fs::File::open(&job.file).await?;
+        let stream = ReaderStream::new(file);
+        let auth = format!(
+            "Nostr {}",
+            BASE64.encode(payload.signed_auth_event.as_bytes())
+        );
+        let response = reqwest::Client::new()
+            .put(upload_url)
+            .header(AUTHORIZATION, auth)
+            .header(CONTENT_TYPE, &job.mime_type)
+            .header(CONTENT_LENGTH, job.size)
+            .header("X-SHA-256", &job.sha256)
+            .body(reqwest::Body::wrap_stream(stream))
+            .send()
+            .await;
+
+        let result = match response {
+            Ok(response) if response.status().is_success() => {
+                let value: serde_json::Value = response.json().await?;
+                let url = value
+                    .get("url")
+                    .and_then(|value| value.as_str())
+                    .ok_or_else(|| Error::Message("Blossom returned no media URL.".into()))?;
+                Ok(UploadedMedia {
+                    url: url.to_owned(),
+                    sha256: value
+                        .get("sha256")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or(&job.sha256)
+                        .to_owned(),
+                    size: value
+                        .get("size")
+                        .and_then(|value| value.as_u64())
+                        .unwrap_or(job.size),
+                    mime_type: job.mime_type.clone(),
+                })
+            }
+            Ok(response) => {
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                Err(Error::Message(format!(
+                    "Blossom upload failed ({status}): {}",
+                    body.chars().take(300).collect::<String>()
+                )))
+            }
+            Err(error) => Err(Error::Http(error)),
+        };
+
+        // A failed upload must start from a fresh hash and authorization. This
+        // also guarantees large files do not linger in the application cache.
+        let _ = self.discard(payload.job_id).await;
+        result
+    }
+
+    pub async fn discard(&self, job_id: String) -> Result<()> {
+        self.preparations
+            .lock()
+            .map_err(|_| Error::Message("Media preparation store is unavailable.".into()))?
+            .remove(&job_id);
+        let job = self
+            .jobs
+            .lock()
+            .map_err(|_| Error::Message("Media job store is unavailable.".into()))?
+            .remove(&job_id);
+        if let Some(job) = job {
+            match fs::remove_dir_all(job.dir).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn cancel(&self, job_id: String) -> Result<()> {
+        self.discard(job_id).await
+    }
+
+    pub fn register_listener(&self, _event: String, _handler: Channel<()>) -> Result<()> {
+        Ok(())
+    }
+
+    pub fn remove_listener(&self, _event: String, _channel_id: u32) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn validate_video_id(video_id: &str) -> Result<()> {
+    if video_id.len() == 11
+        && video_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+    {
+        Ok(())
+    } else {
+        Err(Error::Message("Invalid YouTube video ID.".into()))
+    }
+}
+
+fn validate_job_id(job_id: &str) -> Result<()> {
+    if (8..=80).contains(&job_id.len())
+        && job_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+    {
+        Ok(())
+    } else {
+        Err(Error::Message("Invalid media job ID.".into()))
+    }
+}
+
+fn blossom_upload_url(base: &str) -> Result<Url> {
+    let base = Url::parse(base)?;
+    if base.scheme() != "https" {
+        return Err(Error::Message(
+            "Blossom uploads require an HTTPS server.".into(),
+        ));
+    }
+    Url::parse(&format!("{}/upload", base.as_str().trim_end_matches('/'))).map_err(Into::into)
+}
+
+fn validate_auth_event(raw: &str, hash: &str, server: &str) -> Result<()> {
+    let event: serde_json::Value = serde_json::from_str(raw)?;
+    if event.get("kind").and_then(|value| value.as_u64()) != Some(24242) {
+        return Err(Error::Message("Invalid Blossom authorization kind.".into()));
+    }
+    let tags = event
+        .get("tags")
+        .and_then(|value| value.as_array())
+        .ok_or_else(|| Error::Message("Invalid Blossom authorization tags.".into()))?;
+    let tag_value = |name: &str| {
+        tags.iter().find_map(|tag| {
+            let values = tag.as_array()?;
+            if values.first().and_then(|value| value.as_str()) == Some(name) {
+                values.get(1)?.as_str()
+            } else {
+                None
+            }
+        })
+    };
+    if tag_value("t") != Some("upload")
+        || tag_value("x") != Some(hash)
+        || tag_value("server") != Some(server)
+    {
+        return Err(Error::Message(
+            "Blossom authorization does not match this file and server.".into(),
+        ));
+    }
+    let expiration = tag_value("expiration")
+        .and_then(|value| value.parse::<u64>().ok())
+        .ok_or_else(|| Error::Message("Invalid Blossom authorization expiration.".into()))?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| Error::Message(error.to_string()))?
+        .as_secs();
+    if expiration <= now {
+        return Err(Error::Message("Blossom authorization has expired.".into()));
+    }
+    for field in ["id", "pubkey", "sig"] {
+        if event
+            .get(field)
+            .and_then(|value| value.as_str())
+            .map_or(true, str::is_empty)
+        {
+            return Err(Error::Message(
+                "The Blossom authorization was not signed.".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_executable<R: Runtime>(
+    app: &AppHandle<R>,
+    env_name: &str,
+    bundled_name: &str,
+    development: Option<PathBuf>,
+) -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os(env_name).filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(path));
+    }
+    if let Ok(resource_dir) = app.path().resource_dir() {
+        let bundled = resource_dir.join("bin").join(bundled_name);
+        if bundled.is_file() {
+            return Ok(bundled);
+        }
+    }
+    if let Some(path) = development.filter(|path| path.is_file()) {
+        return Ok(path);
+    }
+    Ok(PathBuf::from(bundled_name))
+}
+
+fn repo_development_binary(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../..")
+        .join(relative)
+}
+
+fn bundled_deno_name() -> &'static str {
+    if cfg!(windows) {
+        "deno.exe"
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        "deno-aarch64"
+    } else if cfg!(target_os = "macos") {
+        "deno-x86_64"
+    } else {
+        "deno"
+    }
+}
+
+async fn find_downloaded_file(dir: &Path) -> Result<PathBuf> {
+    let mut entries = fs::read_dir(dir).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        let incomplete = path
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|value| value == "part" || value == "ytdl");
+        if entry.file_type().await?.is_file() && !incomplete {
+            return Ok(path);
+        }
+    }
+    Err(Error::Message(
+        "The local media engine produced no output file.".into(),
+    ))
+}
+
+async fn hash_file(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn useful_error_tail(stderr: &str) -> String {
+    let lines = stderr
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    lines
+        .iter()
+        .rev()
+        .take(8)
+        .rev()
+        .copied()
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_accepts_a_plain_video_id() {
+        assert!(validate_video_id("dQw4w9WgXcQ").is_ok());
+        assert!(validate_video_id("https://youtube.com/watch?v=dQw4w9WgXcQ").is_err());
+    }
+
+    #[test]
+    fn upload_url_is_https_and_normalized() {
+        assert_eq!(
+            blossom_upload_url("https://blossom.example/")
+                .unwrap()
+                .as_str(),
+            "https://blossom.example/upload"
+        );
+        assert!(blossom_upload_url("http://blossom.example").is_err());
+    }
+}

--- a/src-tauri/plugins/media-acquisition/src/error.rs
+++ b/src-tauri/plugins/media-acquisition/src/error.rs
@@ -1,0 +1,29 @@
+use serde::{ser::Serializer, Serialize};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Message(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[cfg(mobile)]
+    #[error(transparent)]
+    PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
+}

--- a/src-tauri/plugins/media-acquisition/src/lib.rs
+++ b/src-tauri/plugins/media-acquisition/src/lib.rs
@@ -1,0 +1,54 @@
+use tauri::{
+    plugin::{Builder, TauriPlugin},
+    Manager, Runtime,
+};
+
+pub use models::*;
+
+#[cfg(desktop)]
+mod desktop;
+#[cfg(mobile)]
+mod mobile;
+
+mod commands;
+mod error;
+mod models;
+
+pub use error::{Error, Result};
+
+#[cfg(desktop)]
+use desktop::WavefuncMedia;
+#[cfg(mobile)]
+use mobile::WavefuncMedia;
+
+pub trait WavefuncMediaExt<R: Runtime> {
+    fn wavefunc_media(&self) -> &WavefuncMedia<R>;
+}
+
+impl<R: Runtime, T: Manager<R>> WavefuncMediaExt<R> for T {
+    fn wavefunc_media(&self) -> &WavefuncMedia<R> {
+        self.state::<WavefuncMedia<R>>().inner()
+    }
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+    Builder::new("wavefunc-media")
+        .invoke_handler(tauri::generate_handler![
+            commands::prepare,
+            commands::status,
+            commands::upload,
+            commands::discard,
+            commands::cancel,
+            commands::register_listener,
+            commands::remove_listener,
+        ])
+        .setup(|app, api| {
+            #[cfg(mobile)]
+            let media = mobile::init(app, api)?;
+            #[cfg(desktop)]
+            let media = desktop::init(app, api)?;
+            app.manage(media);
+            Ok(())
+        })
+        .build()
+}

--- a/src-tauri/plugins/media-acquisition/src/mobile.rs
+++ b/src-tauri/plugins/media-acquisition/src/mobile.rs
@@ -1,0 +1,128 @@
+use serde::de::DeserializeOwned;
+use tauri::{
+    ipc::Channel,
+    plugin::{PluginApi, PluginHandle},
+    AppHandle, Runtime,
+};
+
+use crate::{
+    PreparationStatus, PrepareRequest, PreparedMedia, RegisterListenerRequest,
+    RemoveListenerRequest, Result, UploadRequest, UploadedMedia,
+};
+
+pub fn init<R: Runtime, C: DeserializeOwned>(
+    _app: &AppHandle<R>,
+    api: PluginApi<R, C>,
+) -> Result<WavefuncMedia<R>> {
+    #[cfg(target_os = "android")]
+    {
+        let handle = api.register_android_plugin("live.wavefunc.media", "WavefuncMediaPlugin")?;
+        return Ok(WavefuncMedia::Android(handle));
+    }
+
+    #[cfg(target_os = "ios")]
+    {
+        let _ = api;
+        Ok(WavefuncMedia::Ios(_app.clone()))
+    }
+}
+
+pub enum WavefuncMedia<R: Runtime> {
+    #[cfg(target_os = "android")]
+    Android(PluginHandle<R>),
+    #[cfg(target_os = "ios")]
+    Ios(AppHandle<R>),
+}
+
+impl<R: Runtime> WavefuncMedia<R> {
+    pub async fn prepare(&self, payload: PrepareRequest) -> Result<PreparedMedia> {
+        match self {
+            #[cfg(target_os = "android")]
+            Self::Android(handle) => handle
+                .run_mobile_plugin("prepare", payload)
+                .map_err(Into::into),
+            #[cfg(target_os = "ios")]
+            Self::Ios(_) => Err(crate::Error::Message(
+                "Local media downloads are not available on iOS.".into(),
+            )),
+        }
+    }
+
+    pub async fn status(&self, job_id: String) -> Result<PreparationStatus> {
+        match self {
+            #[cfg(target_os = "android")]
+            Self::Android(handle) => handle
+                .run_mobile_plugin("status", serde_json::json!({ "jobId": job_id }))
+                .map_err(Into::into),
+            #[cfg(target_os = "ios")]
+            Self::Ios(_) => Ok(PreparationStatus {
+                state: crate::PreparationState::Missing,
+                media: None,
+                error: None,
+            }),
+        }
+    }
+
+    pub async fn upload(&self, payload: UploadRequest) -> Result<UploadedMedia> {
+        match self {
+            #[cfg(target_os = "android")]
+            Self::Android(handle) => handle
+                .run_mobile_plugin("upload", payload)
+                .map_err(Into::into),
+            #[cfg(target_os = "ios")]
+            Self::Ios(_) => Err(crate::Error::Message(
+                "Local media uploads are not available on iOS.".into(),
+            )),
+        }
+    }
+
+    pub async fn discard(&self, job_id: String) -> Result<()> {
+        match self {
+            #[cfg(target_os = "android")]
+            Self::Android(handle) => handle
+                .run_mobile_plugin("discard", serde_json::json!({ "jobId": job_id }))
+                .map_err(Into::into),
+            #[cfg(target_os = "ios")]
+            Self::Ios(_) => Ok(()),
+        }
+    }
+
+    pub async fn cancel(&self, job_id: String) -> Result<()> {
+        match self {
+            #[cfg(target_os = "android")]
+            Self::Android(handle) => handle
+                .run_mobile_plugin("cancel", serde_json::json!({ "jobId": job_id }))
+                .map_err(Into::into),
+            #[cfg(target_os = "ios")]
+            Self::Ios(_) => Ok(()),
+        }
+    }
+
+    pub fn register_listener(&self, event: String, handler: Channel<()>) -> Result<()> {
+        match self {
+            #[cfg(target_os = "android")]
+            Self::Android(handle) => handle
+                .run_mobile_plugin(
+                    "registerListener",
+                    RegisterListenerRequest { event, handler },
+                )
+                .map_err(Into::into),
+            #[cfg(target_os = "ios")]
+            Self::Ios(_) => Ok(()),
+        }
+    }
+
+    pub fn remove_listener(&self, event: String, channel_id: u32) -> Result<()> {
+        match self {
+            #[cfg(target_os = "android")]
+            Self::Android(handle) => handle
+                .run_mobile_plugin(
+                    "removeListener",
+                    RemoveListenerRequest { event, channel_id },
+                )
+                .map_err(Into::into),
+            #[cfg(target_os = "ios")]
+            Self::Ios(_) => Ok(()),
+        }
+    }
+}

--- a/src-tauri/plugins/media-acquisition/src/models.rs
+++ b/src-tauri/plugins/media-acquisition/src/models.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+use tauri::ipc::Channel;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareRequest {
+    pub video_id: String,
+    pub format: MediaFormat,
+    pub job_id: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MediaFormat {
+    Audio,
+    #[serde(rename = "360p")]
+    P360,
+    #[serde(rename = "480p")]
+    P480,
+    #[serde(rename = "720p")]
+    P720,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreparedMedia {
+    pub job_id: String,
+    pub sha256: String,
+    pub size: u64,
+    pub mime_type: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PreparationState {
+    Missing,
+    Preparing,
+    Prepared,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreparationStatus {
+    pub state: PreparationState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media: Option<PreparedMedia>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadRequest {
+    pub job_id: String,
+    pub blossom_url: String,
+    pub signed_auth_event: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UploadedMedia {
+    pub url: String,
+    pub sha256: String,
+    pub size: u64,
+    pub mime_type: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegisterListenerRequest {
+    pub event: String,
+    pub handler: Channel<()>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveListenerRequest {
+    pub event: String,
+    pub channel_id: u32,
+}

--- a/src-tauri/resources/bin/README.md
+++ b/src-tauri/resources/bin/README.md
@@ -1,0 +1,3 @@
+Desktop release builds place the platform-specific `yt-dlp` and Deno binaries
+in this directory before Tauri packages the application. They are intentionally
+not committed because they are large generated release inputs.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ fn update_now_playing(app: tauri::AppHandle, np: NowPlaying) -> Result<(), Strin
 pub fn run() {
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_wavefunc_player::init())
+        .plugin(tauri_plugin_wavefunc_media::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WaveFunc",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "live.wavefunc.app",
   "build": {
     "beforeDevCommand": "bun run dev:frontend",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,6 +35,9 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "resources": {
+      "resources/bin/*": "bin/"
+    },
     "publisher": "WaveFunc",
     "copyright": "",
     "category": "Music",

--- a/src/components/FloatingPlayer.tsx
+++ b/src/components/FloatingPlayer.tsx
@@ -22,11 +22,12 @@ import { NavigationItems } from "./NavigationItems";
 import { UnifiedSearchInput } from "./UnifiedSearchInput";
 import { LoginSessionButtons } from "./LoginSessionButtom";
 import { SongFavoriteButton } from "./SongFavoriteButton";
+import { SongMagicButton } from "./SongMagicButton";
 import { useCurrentAccount } from "../lib/nostr/auth";
 
 // ─── Snap levels ──────────────────────────────────────────────────────────────
 
-const PEEK_VH = 45;
+const PEEK_VH = 60;
 const EXPANDED_VH = 82;
 const SNAP_THRESHOLD_VH = (PEEK_VH + EXPANDED_VH) / 2;
 
@@ -243,9 +244,7 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
     if (sheetSnap === "expanded") {
       setSheetSnap("peek");
     } else {
-      closeSheet();
-      setDragHeightVh(null);
-      dragHeightRef.current = null;
+      setSheetSnap("expanded");
     }
   };
 
@@ -303,14 +302,16 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
             onPointerDown={handleDragStart}
             onClick={handleGrabberClick}
             onKeyDown={handleGrabberKeyDown}
-            className="w-full shrink-0 flex items-center justify-center py-2.5 touch-none cursor-ns-resize hover:bg-surface-container-high transition-colors"
+            className="w-full h-12 shrink-0 flex items-center justify-center touch-none cursor-ns-resize hover:bg-surface-container-high transition-colors"
             aria-label="Resize panel"
+            title={sheetSnap === "expanded" ? "Collapse panel" : "Expand panel"}
           >
             <div className="flex items-center justify-between w-full px-4">
               <div className="w-6" />
               <div className="h-1 w-12 bg-on-background/30 rounded-full" />
               <button
                 type="button"
+                onPointerDown={(e) => e.stopPropagation()}
                 onClick={(e) => { e.stopPropagation(); closeSheet(); setDragHeightVh(null); dragHeightRef.current = null; }}
                 className="w-6 h-6 flex items-center justify-center text-on-background/40 hover:text-on-background transition-colors"
                 aria-label="Close"
@@ -375,6 +376,7 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
                   {currentMetadata.artist && <span className="opacity-70"> · {currentMetadata.artist}</span>}
                 </p>
                 <SongFavoriteButton size="sm" className="shrink-0" />
+                <SongMagicButton size="sm" className="shrink-0" />
               </div>
             )}
           </div>
@@ -552,6 +554,7 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
                     {currentMetadata.artist && <span className="opacity-60"> • {currentMetadata.artist}</span>}
                   </p>
                   <SongFavoriteButton size="sm" className="shrink-0" />
+                  <SongMagicButton size="sm" className="shrink-0" />
                 </div>
               )}
               {isPlaying && !currentMetadata?.song && <Skeleton className="h-3 w-24 mt-0.5" />}

--- a/src/components/Nip46LoginDialog.tsx
+++ b/src/components/Nip46LoginDialog.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { openUrl } from "../lib/openUrl";
 import { QRCodeSVG } from "qrcode.react";
 import { NostrConnectSigner } from "applesauce-signers";
+import { detectPlatform } from "../lib/platform";
+import { nip46ClientName } from "../lib/nostr/nip46";
 import {
   Dialog,
   DialogContent,
@@ -31,11 +33,6 @@ type ConnectionState =
   | "waiting"
   | "connected"
   | "error";
-
-const CONNECTION_APP_NAME =
-  process.env.NODE_ENV === "production"
-    ? "Wavefunc Radio"
-    : "Wavefunc Radio DEV";
 
 export function Nip46LoginDialog({ trigger, onLogin }: Nip46LoginDialogProps) {
   const { createNostrConnectSigner, loginWithConnectSigner } =
@@ -117,13 +114,14 @@ export function Nip46LoginDialog({ trigger, onLogin }: Nip46LoginDialogProps) {
       setState("generating");
       setError(null);
       try {
+        const platform = await detectPlatform();
         const signer = createNostrConnectSigner({
           relays: [selectedRelay],
         });
         signerRef.current = signer;
 
         const uri = signer.getNostrConnectURI({
-          name: CONNECTION_APP_NAME,
+          name: nip46ClientName(platform),
           url: window.location.origin,
         });
 

--- a/src/components/ShareSongDialog.tsx
+++ b/src/components/ShareSongDialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { buildShareSongNoteTemplate, type ParsedSong } from "../lib/nostr/domain";
 import { useWavefuncNostr } from "../lib/nostr/runtime";
+import { mediaErrorMessage } from "../lib/mediaAcquisition";
 import { cn } from "@/lib/utils";
 
 interface ShareSongDialogProps {
@@ -122,19 +124,21 @@ export function ShareSongDialog({ song, onClose }: ShareSongDialogProps) {
       });
       await signAndPublish(template);
       setPhase("done");
-    } catch (err: any) {
-      setErrorMsg(err.message ?? "Publish failed");
+    } catch (error) {
+      setErrorMsg(mediaErrorMessage(error, "Publish failed."));
       setPhase("error");
     }
   };
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[110] flex items-center justify-center p-2 sm:p-4">
       {/* Backdrop */}
       <div className="absolute inset-0 bg-background/80 backdrop-blur-sm" onClick={onClose} />
 
       {/* Panel */}
-      <div className="relative w-full max-w-lg border-4 border-on-background bg-background shadow-[8px_8px_0px_0px_rgba(29,28,19,1)]">
+      <div className="relative max-h-[calc(100dvh-1rem)] w-full max-w-lg overflow-y-auto border-4 border-on-background bg-background shadow-[8px_8px_0px_0px_rgba(29,28,19,1)] sm:max-h-[calc(100dvh-2rem)]">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 bg-on-background text-surface">
           <span className="text-[11px] font-black uppercase tracking-widest flex items-center gap-1.5">
@@ -292,7 +296,7 @@ export function ShareSongDialog({ song, onClose }: ShareSongDialogProps) {
           {phase === "error" && (
             <div className="flex items-center gap-2">
               <span className="material-symbols-outlined text-[14px] text-destructive shrink-0">error</span>
-              <p className="text-[10px] font-bold uppercase tracking-tight text-destructive truncate flex-1">{errorMsg}</p>
+              <p className="flex-1 whitespace-pre-wrap break-words text-[10px] font-bold uppercase tracking-tight text-destructive">{errorMsg}</p>
               <button
                 type="button"
                 onClick={() => { setPhase("compose"); setErrorMsg(null); }}
@@ -304,6 +308,7 @@ export function ShareSongDialog({ song, onClose }: ShareSongDialogProps) {
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/components/SongMagicButton.tsx
+++ b/src/components/SongMagicButton.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { useCurrentAccount } from "../lib/nostr/auth";
+import { useMetadataStore } from "../stores/metadataStore";
+import { useUIStore } from "../stores/uiStore";
+import { cn } from "@/lib/utils";
+import { SongMediaDialog } from "./SongMediaDialog";
+
+interface SongMagicButtonProps {
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function SongMagicButton({ size = "sm", className }: SongMagicButtonProps) {
+  const currentUser = useCurrentAccount();
+  const metadata = useMetadataStore((state) => state.currentMetadata);
+  const pulseLogin = useUIStore((state) => state.pulseLogin);
+  const [open, setOpen] = useState(false);
+
+  if (!metadata?.song || metadata.song === "No metadata available") return null;
+
+  const handleClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (!currentUser) {
+      pulseLogin();
+      return;
+    }
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        className={cn(
+          "flex items-center justify-center text-on-background/40 transition-colors hover:text-primary",
+          className,
+        )}
+        title="Save audio or video to Blossom"
+      >
+        <span className={cn("material-symbols-outlined", size === "sm" ? "text-[14px]" : "text-[18px]")}>auto_fix_high</span>
+      </button>
+      {open && <SongMediaDialog metadata={metadata} onClose={() => setOpen(false)} />}
+    </>
+  );
+}

--- a/src/components/SongMediaDialog.tsx
+++ b/src/components/SongMediaDialog.tsx
@@ -1,0 +1,481 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  getMetadataClient,
+  type YouTubeResult,
+} from "../ctxcn/WavefuncMetadataServerClient";
+import { usePlatform } from "../lib/hooks/usePlatform";
+import { useCurrentAccount } from "../lib/nostr/auth";
+import {
+  type ParsedSong,
+  type SongMetadataInput,
+} from "../lib/nostr/domain";
+import { forgeAndFavoriteSong } from "../lib/nostr/forgeSong";
+import { useWavefuncNostr } from "../lib/nostr/runtime";
+import { useSongFavorites } from "../lib/hooks/useSongFavorites";
+import {
+  createInstalledMediaAcquirer,
+  mediaAcquisitionAvailability,
+  mediaErrorMessage,
+  type MediaFormat,
+} from "../lib/mediaAcquisition";
+import { useUIStore } from "../stores/uiStore";
+import { cn } from "@/lib/utils";
+import { ShareSongDialog } from "./ShareSongDialog";
+import { YoutubeEmbed } from "./YoutubeEmbed";
+
+export const DEFAULT_BLOSSOM_URL = "https://blossom.band";
+
+const BLOSSOM_SERVERS = [
+  { label: "BLOSSOM.BAND", url: DEFAULT_BLOSSOM_URL },
+  { label: "HZRD149", url: "https://cdn.hzrd149.com" },
+  { label: "V0L.IO", url: "https://files.v0l.io" },
+] as const;
+
+const VIDEO_FORMATS: { label: string; format: Exclude<MediaFormat, "audio"> }[] = [
+  { label: "360P", format: "360p" },
+  { label: "480P", format: "480p" },
+  { label: "720P", format: "720p" },
+];
+
+type Phase =
+  | "searching"
+  | "results"
+  | "downloading"
+  | "authorizing"
+  | "uploading"
+  | "error";
+
+interface SongMediaDialogProps {
+  song?: ParsedSong;
+  metadata?: SongMetadataInput;
+  onClose: () => void;
+}
+
+function formatDuration(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+export function SongMediaDialog({ song, metadata, onClose }: SongMediaDialogProps) {
+  const currentUser = useCurrentAccount();
+  const pulseLogin = useUIStore((state) => state.pulseLogin);
+  const { signer, signAndPublish } = useWavefuncNostr();
+  const { addToDefaultList } = useSongFavorites();
+  const platform = usePlatform();
+  const acquisition = mediaAcquisitionAvailability(platform);
+
+  const [phase, setPhase] = useState<Phase>("searching");
+  const [results, setResults] = useState<YouTubeResult[]>([]);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [progressMsg, setProgressMsg] = useState<string | null>(null);
+  const [activeVideoId, setActiveVideoId] = useState<string | null>(null);
+  const [watchingId, setWatchingId] = useState<string | null>(null);
+  const [mediaType, setMediaType] = useState<"audio" | "video">("audio");
+  const [videoFormat, setVideoFormat] = useState<Exclude<MediaFormat, "audio">>("360p");
+  const [blossomUrl, setBlossomUrl] = useState(DEFAULT_BLOSSOM_URL);
+  const [customBlossom, setCustomBlossom] = useState("");
+  const [useCustomBlossom, setUseCustomBlossom] = useState(false);
+  const [shareSong, setShareSong] = useState<ParsedSong | null>(null);
+
+  const title = song?.title || metadata?.musicBrainz?.title || metadata?.song || "";
+  const artist = song?.artist || metadata?.musicBrainz?.artist || metadata?.artist || "";
+  const query = useMemo(() => [title, artist].filter(Boolean).join(" "), [artist, title]);
+  const format: MediaFormat = mediaType === "audio" ? "audio" : videoFormat;
+  const effectiveBlossomUrl = useCustomBlossom ? customBlossom.trim() : blossomUrl;
+
+  const search = useCallback(async () => {
+    if (!query) {
+      setErrorMsg("No track metadata is available for this search.");
+      setPhase("error");
+      return;
+    }
+
+    setErrorMsg(null);
+    setPhase("searching");
+    try {
+      const output = await getMetadataClient().SearchYouTube(query, 5);
+      setResults(output.results);
+      setPhase("results");
+    } catch (error) {
+      setErrorMsg(mediaErrorMessage(error, "YouTube search failed."));
+      setPhase("error");
+    }
+  }, [query]);
+
+  useEffect(() => {
+    if (!currentUser) {
+      pulseLogin();
+      onClose();
+      return;
+    }
+    void search();
+    // Opening the dialog is the search trigger; parent callback identity is irrelevant.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && phase !== "downloading" && phase !== "uploading") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, phase]);
+
+  const saveMedia = async (result: YouTubeResult) => {
+    if (!signer || !currentUser) {
+      pulseLogin();
+      return;
+    }
+    if (acquisition.mode !== "local") {
+      setErrorMsg(acquisition.reason);
+      setPhase("error");
+      return;
+    }
+    if (!effectiveBlossomUrl) {
+      setErrorMsg("Choose a Blossom server before starting the transfer.");
+      setPhase("error");
+      return;
+    }
+
+    setActiveVideoId(result.videoId);
+    setErrorMsg(null);
+    setProgressMsg("Saving to Liked Songs…");
+    setPhase("downloading");
+
+    try {
+      const persistedSong = await forgeAndFavoriteSong({
+        song,
+        metadata,
+        videoId: result.videoId,
+        favorite: async (address) => {
+          await addToDefaultList(address);
+        },
+        acquireMedia: async () => {
+          setProgressMsg("Starting local media engine…");
+          const mediaAcquirer = await createInstalledMediaAcquirer();
+          return mediaAcquirer.save({
+            videoId: result.videoId,
+            format,
+            blossomUrl: effectiveBlossomUrl,
+            signEvent: (template) => signer.signEvent(template),
+            onProgress: (progress) => {
+              setPhase(
+                progress.stage === "uploading"
+                  ? "uploading"
+                  : progress.stage === "authorizing"
+                    ? "authorizing"
+                    : "downloading",
+              );
+              setProgressMsg(progress.message ?? null);
+            },
+          });
+        },
+        publish: (template) => signAndPublish(template),
+      });
+      setShareSong(persistedSong);
+    } catch (error) {
+      setErrorMsg(mediaErrorMessage(error, "Media download failed."));
+      setActiveVideoId(null);
+      setPhase("error");
+    }
+  };
+
+  if (shareSong) {
+    return <ShareSongDialog song={shareSong} onClose={onClose} />;
+  }
+
+  if (typeof document === "undefined") return null;
+
+  const transferring =
+    phase === "downloading" || phase === "authorizing" || phase === "uploading";
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-2 sm:p-4">
+      <button
+        type="button"
+        aria-label="Close media forge"
+        className="absolute inset-0 bg-background/85 backdrop-blur-sm"
+        onClick={transferring ? undefined : onClose}
+      />
+
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-label="Save song to Blossom"
+        className="relative flex max-h-[calc(100dvh-1rem)] w-full max-w-2xl flex-col border-4 border-on-background bg-background shadow-[8px_8px_0px_0px_rgba(29,28,19,1)] sm:max-h-[calc(100dvh-2rem)]"
+      >
+        <header className="flex shrink-0 items-center justify-between gap-3 bg-on-background px-4 py-3 text-surface">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="material-symbols-outlined text-[17px]">auto_fix_high</span>
+              <h2 className="text-[12px] font-black uppercase tracking-widest">MEDIA_FORGE</h2>
+            </div>
+            <p className="mt-0.5 truncate text-[9px] font-bold uppercase tracking-widest text-surface/55">
+              {title || "UNKNOWN_TRACK"}{artist ? ` · ${artist}` : ""}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={transferring}
+            className="shrink-0 text-surface/55 transition-colors hover:text-surface disabled:opacity-30"
+            title={transferring ? "Wait for the active transfer" : "Close"}
+          >
+            <span className="material-symbols-outlined text-[18px]">close</span>
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-3 sm:p-4">
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => setMediaType("audio")}
+              disabled={transferring}
+              className={cn(
+                "flex min-h-12 items-center gap-2 border-2 px-3 text-left transition-colors",
+                mediaType === "audio"
+                  ? "border-on-background bg-on-background text-surface"
+                  : "border-on-background/25 hover:border-on-background",
+              )}
+            >
+              <span className="material-symbols-outlined text-[18px]">audio_file</span>
+              <span>
+                <span className="block text-[10px] font-black uppercase tracking-widest">AUDIO_ONLY</span>
+                <span className="block text-[8px] font-bold uppercase opacity-55">SMALLER_FILE</span>
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setMediaType("video")}
+              disabled={transferring}
+              className={cn(
+                "flex min-h-12 items-center gap-2 border-2 px-3 text-left transition-colors",
+                mediaType === "video"
+                  ? "border-on-background bg-on-background text-surface"
+                  : "border-on-background/25 hover:border-on-background",
+              )}
+            >
+              <span className="material-symbols-outlined text-[18px]">video_file</span>
+              <span>
+                <span className="block text-[10px] font-black uppercase tracking-widest">VIDEO</span>
+                <span className="block text-[8px] font-bold uppercase opacity-55">PICTURE_+_SOUND</span>
+              </span>
+            </button>
+          </div>
+
+          {mediaType === "video" && (
+            <div>
+              <p className="mb-1.5 text-[9px] font-black uppercase tracking-widest text-on-background/45">VIDEO_QUALITY</p>
+              <div className="grid grid-cols-3 gap-2">
+                {VIDEO_FORMATS.map((choice) => (
+                  <button
+                    key={choice.format}
+                    type="button"
+                    onClick={() => setVideoFormat(choice.format)}
+                    disabled={transferring}
+                    className={cn(
+                      "border-2 px-2 py-2 text-[10px] font-black uppercase tracking-widest transition-colors",
+                      videoFormat === choice.format
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-on-background/25 hover:border-on-background",
+                    )}
+                  >
+                    {choice.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div>
+            <div className="mb-1.5 flex items-end justify-between gap-2">
+              <p className="text-[9px] font-black uppercase tracking-widest text-on-background/45">BLOSSOM_DESTINATION</p>
+              <p className="text-[8px] font-bold uppercase tracking-widest text-primary">DEFAULT: BLOSSOM.BAND</p>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {BLOSSOM_SERVERS.map((server) => (
+                <button
+                  key={server.url}
+                  type="button"
+                  onClick={() => {
+                    setBlossomUrl(server.url);
+                    setUseCustomBlossom(false);
+                  }}
+                  disabled={transferring}
+                  className={cn(
+                    "border px-2 py-1 text-[9px] font-black uppercase tracking-widest transition-colors",
+                    !useCustomBlossom && blossomUrl === server.url
+                      ? "border-on-background bg-on-background text-surface"
+                      : "border-on-background/25 hover:border-on-background",
+                  )}
+                >
+                  {server.label}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => setUseCustomBlossom(true)}
+                disabled={transferring}
+                className={cn(
+                  "border px-2 py-1 text-[9px] font-black uppercase tracking-widest transition-colors",
+                  useCustomBlossom
+                    ? "border-on-background bg-on-background text-surface"
+                    : "border-on-background/25 hover:border-on-background",
+                )}
+              >
+                CUSTOM
+              </button>
+            </div>
+            {useCustomBlossom && (
+              <input
+                type="url"
+                value={customBlossom}
+                onChange={(event) => setCustomBlossom(event.target.value)}
+                placeholder="https://your-blossom-server.example"
+                disabled={transferring}
+                className="mt-2 w-full border-2 border-on-background/25 bg-transparent px-3 py-2 font-mono text-[10px] outline-none placeholder:text-on-background/25 focus:border-on-background"
+              />
+            )}
+          </div>
+
+          <div className="border-y-2 border-on-background/15 py-2">
+            <p className="text-[8px] font-black uppercase tracking-[0.18em] text-on-background/45">
+              SEARCH VIA CONTEXTVM · DOWNLOAD ON THIS DEVICE · UPLOAD DIRECT TO BLOSSOM
+            </p>
+          </div>
+
+          {acquisition.mode === "app-required" && (
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-2 border-primary/50 bg-primary/5 p-3">
+              <p className="text-[10px] font-bold uppercase leading-relaxed text-on-background/70">
+                Local media downloads require WaveFunc for Android or desktop.
+              </p>
+              <a
+                href="/apps"
+                className="border-2 border-on-background bg-on-background px-3 py-1.5 text-[9px] font-black uppercase tracking-widest text-surface"
+              >
+                GET_APP
+              </a>
+            </div>
+          )}
+
+          {phase === "searching" && (
+            <div className="flex items-center gap-2 py-6 text-on-background/45">
+              <span className="material-symbols-outlined text-[18px]" style={{ animation: "spin 0.8s linear infinite" }}>sync</span>
+              <span className="text-[10px] font-black uppercase tracking-widest">SCANNING_RESULTS...</span>
+            </div>
+          )}
+
+          {watchingId && (
+            <YoutubeEmbed videoId={watchingId} onClose={() => setWatchingId(null)} />
+          )}
+
+          {phase === "results" && results.length === 0 && (
+            <p className="py-6 text-center text-[10px] font-bold uppercase tracking-widest text-on-background/40">NO_RESULTS_FOUND</p>
+          )}
+
+          {phase === "results" && results.length > 0 && (
+            <div className="space-y-2">
+              {results.map((result) => (
+                <article
+                  key={result.videoId}
+                  className="grid grid-cols-[64px_minmax(0,1fr)] gap-x-3 gap-y-2 border-2 border-on-background/15 p-2 sm:grid-cols-[80px_minmax(0,1fr)_auto] sm:items-center"
+                >
+                  <div className="row-span-2 aspect-video overflow-hidden bg-on-background/10 sm:row-span-1">
+                    {result.thumbnailUrl ? (
+                      <img
+                        src={result.thumbnailUrl}
+                        alt=""
+                        className="h-full w-full object-cover"
+                        onError={(event) => { event.currentTarget.style.display = "none"; }}
+                      />
+                    ) : (
+                      <span className="material-symbols-outlined flex h-full items-center justify-center text-on-background/25">smart_display</span>
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-[11px] font-black uppercase tracking-tight">{result.title}</p>
+                    <p className="truncate text-[9px] text-on-background/50">
+                      {result.channel}
+                      {result.duration ? <span className="ml-2 tabular-nums">{formatDuration(result.duration)}</span> : null}
+                    </p>
+                  </div>
+                  <div className="col-start-2 flex flex-wrap gap-1.5 sm:col-start-3 sm:row-start-1 sm:justify-end">
+                    <button
+                      type="button"
+                      onClick={() => setWatchingId(result.videoId)}
+                      className="border border-on-background/25 px-2 py-1 text-[9px] font-black uppercase tracking-widest transition-colors hover:border-on-background hover:bg-on-background hover:text-surface"
+                    >
+                      PREVIEW
+                    </button>
+                    {acquisition.mode === "local" && (
+                      <button
+                        type="button"
+                        onClick={() => void saveMedia(result)}
+                        disabled={!effectiveBlossomUrl}
+                        className="flex items-center gap-1 border-2 border-primary bg-primary px-2 py-1 text-[9px] font-black uppercase tracking-widest text-primary-foreground transition-opacity hover:opacity-80 disabled:opacity-35"
+                      >
+                        <span className="material-symbols-outlined text-[13px]">auto_fix_high</span>
+                        FORGE_{format === "audio" ? "AUDIO" : format.toUpperCase()}
+                      </button>
+                    )}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+
+          {transferring && (
+            <div className="border-2 border-on-background bg-on-background p-3 text-surface">
+              <div className="flex items-start gap-2">
+                <span className="material-symbols-outlined shrink-0 text-[18px]" style={{ animation: "spin 0.8s linear infinite" }}>sync</span>
+                <div className="min-w-0">
+                  <p className="text-[10px] font-black uppercase tracking-widest">
+                    {phase === "uploading"
+                      ? "UPLOADING_TO_BLOSSOM..."
+                      : phase === "authorizing"
+                        ? "WAITING_FOR_SIGNER_APPROVAL..."
+                        : "DOWNLOADING_ON_DEVICE..."}
+                  </p>
+                  <p className="mt-1 break-words font-mono text-[9px] leading-relaxed text-surface/60">
+                    {progressMsg || `Processing ${activeVideoId || "selection"}…`}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {phase === "error" && (
+            <div className="border-2 border-destructive bg-destructive/5 p-3 text-destructive">
+              <div className="flex items-start gap-2">
+                <span className="material-symbols-outlined shrink-0 text-[17px]">error</span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[9px] font-black uppercase tracking-widest">TRANSFER_ABORTED</p>
+                  <p className="mt-1 max-h-36 overflow-y-auto whitespace-pre-wrap break-words font-mono text-[10px] leading-relaxed">
+                    {errorMsg}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-3 flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setErrorMsg(null);
+                    setPhase(results.length > 0 ? "results" : "searching");
+                    if (results.length === 0) void search();
+                  }}
+                  className="border border-destructive px-3 py-1 text-[9px] font-black uppercase tracking-widest hover:bg-destructive hover:text-white"
+                >
+                  RETRY
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/src/lib/hooks/useSongFavorites.ts
+++ b/src/lib/hooks/useSongFavorites.ts
@@ -27,6 +27,7 @@ import {
   WF_SONG_LIST_KIND,
 } from "../nostr/domain";
 import { useWavefuncNostr } from "../nostr/runtime";
+import { requestEventsIntoStore } from "../nostr/requestEvents";
 
 const DEFAULT_LIST_NAME = "Liked Songs";
 
@@ -45,25 +46,34 @@ export function useSongFavorites() {
     ];
   }, [currentUser?.pubkey]);
 
-  // Keep an active relay subscription so song list events get loaded into
-  // the store and stay fresh. Events flow into the store via storeEvents,
-  // which triggers insert$/remove$ → the TimelineModel below picks them up.
-  const [eose, setEose] = useState(false);
+  // A finite request owns the initial loading lifecycle. The live subscription
+  // intentionally has no EOSE value, so it cannot be used to release skeletons.
+  const [initialLoadComplete, setInitialLoadComplete] = useState(false);
   useEffect(() => {
     if (!filters) {
-      setEose(true);
+      setInitialLoadComplete(true);
       return;
     }
-    setEose(false);
-    const subscription = relayPool
+
+    setInitialLoadComplete(false);
+    const requestSubscription = requestEventsIntoStore(
+      relayPool,
+      eventStore,
+      getAppDataRelayUrls(),
+      filters,
+    ).subscribe({
+      complete: () => setInitialLoadComplete(true),
+      error: () => setInitialLoadComplete(true),
+    });
+    const liveSubscription = relayPool
       .subscription(getAppDataRelayUrls(), filters)
       .pipe(storeEvents(eventStore))
-      .subscribe({
-        next: (message) => {
-          if (message === "EOSE") setEose(true);
-        },
-      });
-    return () => subscription.unsubscribe();
+      .subscribe();
+
+    return () => {
+      requestSubscription.unsubscribe();
+      liveSubscription.unsubscribe();
+    };
   }, [eventStore, relayPool, filters]);
 
   // useEventModel subscribes to a shared TimelineModel on the EventStore via
@@ -76,7 +86,7 @@ export function useSongFavorites() {
     [events],
   );
 
-  const isLoading = !eose;
+  const isLoading = !initialLoadComplete;
 
   const isInAnyList = useCallback(
     (songAddress: string) =>
@@ -110,7 +120,7 @@ export function useSongFavorites() {
         return true;
       } catch (err) {
         console.error("Failed to add song to list:", err);
-        return false;
+        throw err;
       }
     },
     [findOrCreateDefaultList, signAndPublish],

--- a/src/lib/mediaAcquisition.ts
+++ b/src/lib/mediaAcquisition.ts
@@ -1,0 +1,331 @@
+import type { PlatformInfo } from "./platform";
+
+export type MediaFormat = "audio" | "360p" | "480p" | "720p";
+
+export interface PreparedMedia {
+  jobId: string;
+  sha256: string;
+  size: number;
+  mimeType: string;
+}
+
+interface NativePreparationStatus {
+  state: "missing" | "preparing" | "prepared" | "failed";
+  media?: PreparedMedia;
+  error?: string;
+}
+
+export interface UploadedMedia {
+  url: string;
+  sha256: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface MediaProgress {
+  stage: "preparing" | "downloading" | "hashing" | "authorizing" | "uploading";
+  progress?: number;
+  message?: string;
+}
+
+export interface NativeMediaAdapter {
+  prepare(
+    payload: { videoId: string; format: MediaFormat },
+    onProgress?: (progress: MediaProgress) => void,
+  ): Promise<PreparedMedia>;
+  upload(
+    payload: {
+      jobId: string;
+      blossomUrl: string;
+      signedAuthEvent: string;
+    },
+    onProgress?: (progress: MediaProgress) => void,
+  ): Promise<UploadedMedia>;
+  discard(jobId: string): Promise<void>;
+  cancel(jobId: string): Promise<void>;
+}
+
+export interface UnsignedEvent {
+  kind: number;
+  content: string;
+  created_at: number;
+  tags: string[][];
+}
+
+export interface SaveMediaRequest {
+  videoId: string;
+  format: MediaFormat;
+  blossomUrl: string;
+  signEvent(event: UnsignedEvent): unknown | Promise<unknown>;
+  onProgress?: (progress: MediaProgress) => void;
+}
+
+export type NativeInvoke = <T>(command: string, args?: unknown) => Promise<T>;
+
+interface TauriMediaAdapterOptions {
+  createJobId?: () => string;
+  pollIntervalMs?: number;
+  maxPollAttempts?: number;
+}
+
+export type MediaAcquisitionAvailability =
+  | { mode: "local" }
+  | { mode: "app-required"; reason: string };
+
+const APP_REQUIRED_REASON =
+  "Install WaveFunc for Android or desktop to save media locally.";
+
+export function mediaErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  if (error && typeof error === "object") {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim()) return message;
+  }
+  return fallback;
+}
+
+function nativeMediaError(error: unknown, fallback: string): Error {
+  return error instanceof Error
+    ? error
+    : new Error(mediaErrorMessage(error, fallback));
+}
+
+function createMediaJobId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  milliseconds: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), milliseconds);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Media extraction has to run in an installed app so it shares the user's
+ * network identity and can continue while the web view is backgrounded.
+ */
+export function mediaAcquisitionAvailability(
+  platform: PlatformInfo,
+): MediaAcquisitionAvailability {
+  if (
+    platform.isTauri &&
+    (platform.isAndroid || platform.isDesktop)
+  ) {
+    return { mode: "local" };
+  }
+
+  return { mode: "app-required", reason: APP_REQUIRED_REASON };
+}
+
+export function createMediaAcquirer(
+  adapter: NativeMediaAdapter,
+  now: () => number = () => Math.floor(Date.now() / 1000),
+  signerTimeoutMs = 90_000,
+) {
+  return {
+    async save(request: SaveMediaRequest): Promise<UploadedMedia> {
+      if (!/^[A-Za-z0-9_-]{11}$/.test(request.videoId)) {
+        throw new Error("Invalid YouTube video ID.");
+      }
+
+      const blossomUrl = new URL(request.blossomUrl);
+      if (blossomUrl.protocol !== "https:") {
+        throw new Error("Blossom uploads require an HTTPS server.");
+      }
+
+      const prepared = await adapter.prepare(
+        { videoId: request.videoId, format: request.format },
+        request.onProgress,
+      );
+
+      try {
+        const createdAt = now();
+        request.onProgress?.({
+          stage: "authorizing",
+          message: "Waiting for approval in your Nostr signer…",
+        });
+        const authEvent = await withTimeout(
+          Promise.resolve(request.signEvent({
+            kind: 24242,
+            content: `Upload ${request.format} to ${blossomUrl.hostname.toLowerCase()}`,
+            created_at: createdAt,
+            tags: [
+              ["t", "upload"],
+              ["x", prepared.sha256],
+              ["expiration", String(createdAt + 600)],
+              ["server", blossomUrl.hostname.toLowerCase()],
+            ],
+          })),
+          signerTimeoutMs,
+          "Signer approval timed out. Open your signer app, check its connection, and try again.",
+        );
+
+        return await adapter.upload(
+          {
+            jobId: prepared.jobId,
+            blossomUrl: blossomUrl.toString(),
+            signedAuthEvent: JSON.stringify(authEvent),
+          },
+          request.onProgress,
+        );
+      } catch (error) {
+        await adapter.discard(prepared.jobId).catch(() => undefined);
+        throw error;
+      }
+    },
+  };
+}
+
+export function createTauriMediaAdapter(
+  invoke: NativeInvoke,
+  options: TauriMediaAdapterOptions = {},
+): NativeMediaAdapter {
+  const createJobId = options.createJobId ?? createMediaJobId;
+  const pollIntervalMs = options.pollIntervalMs ?? 1_000;
+  const maxPollAttempts = options.maxPollAttempts ?? 16 * 60;
+
+  return {
+    async prepare(payload, onProgress) {
+      onProgress?.({ stage: "preparing", message: "Preparing local download…" });
+      const jobId = createJobId();
+      let settled = false;
+      const directResponse = invoke<PreparedMedia>("plugin:wavefunc-media|prepare", {
+        payload: { ...payload, jobId },
+      });
+      const recoveredResponse = (async (): Promise<PreparedMedia> => {
+        for (let attempt = 0; attempt < maxPollAttempts; attempt += 1) {
+          await wait(pollIntervalMs);
+          if (settled) return new Promise<PreparedMedia>(() => undefined);
+
+          let status: NativePreparationStatus;
+          try {
+            status = await invoke<NativePreparationStatus>(
+              "plugin:wavefunc-media|status",
+              { jobId },
+            );
+          } catch {
+            // The WebView/native bridge can be temporarily unavailable while
+            // Android backgrounds the activity. The direct response may still
+            // arrive, and the next status check can recover it after resume.
+            continue;
+          }
+
+          if (status.state === "prepared" && status.media) return status.media;
+          if (status.state === "failed") {
+            throw new Error(status.error || "Local media download failed.");
+          }
+        }
+        throw new Error("Local media preparation timed out. Please try again.");
+      })();
+
+      try {
+        return await Promise.race([directResponse, recoveredResponse]);
+      } catch (error) {
+        throw nativeMediaError(error, "Local media download failed.");
+      } finally {
+        settled = true;
+      }
+    },
+    async upload(payload, onProgress) {
+      onProgress?.({ stage: "uploading", message: "Uploading to Blossom…" });
+      try {
+        return await invoke<UploadedMedia>("plugin:wavefunc-media|upload", {
+          payload,
+        });
+      } catch (error) {
+        throw nativeMediaError(error, "Blossom upload failed.");
+      }
+    },
+    async discard(jobId) {
+      try {
+        await invoke<void>("plugin:wavefunc-media|discard", { jobId });
+      } catch (error) {
+        throw nativeMediaError(error, "Could not discard local media.");
+      }
+    },
+    async cancel(jobId) {
+      try {
+        await invoke<void>("plugin:wavefunc-media|cancel", { jobId });
+      } catch (error) {
+        throw nativeMediaError(error, "Could not cancel media download.");
+      }
+    },
+  };
+}
+
+let installedAcquirer: Promise<ReturnType<typeof createMediaAcquirer>> | null = null;
+
+export function createInstalledMediaAcquirer() {
+  installedAcquirer ??= (async () => {
+    const { invoke, addPluginListener } = await import("@tauri-apps/api/core");
+    const native = createTauriMediaAdapter(invoke as NativeInvoke);
+    let activeProgress: SaveMediaRequest["onProgress"];
+    let activeTransfer = false;
+
+    // The Android engine reports real yt-dlp and upload progress. Desktop has
+    // the same command surface and receives the coarse stage updates below.
+    await addPluginListener<MediaProgress>(
+      "wavefunc-media",
+      "progress",
+      (event) => activeProgress?.(event),
+    );
+
+    const adapter: NativeMediaAdapter = {
+      ...native,
+      async prepare(payload, onProgress) {
+        if (activeTransfer) {
+          throw new Error("Another media transfer is already running.");
+        }
+        activeTransfer = true;
+        activeProgress = onProgress;
+        try {
+          return await native.prepare(payload, onProgress);
+        } catch (error) {
+          activeProgress = undefined;
+          activeTransfer = false;
+          throw error;
+        }
+      },
+      async upload(payload, onProgress) {
+        activeProgress = onProgress;
+        try {
+          return await native.upload(payload, onProgress);
+        } finally {
+          activeProgress = undefined;
+          activeTransfer = false;
+        }
+      },
+      async discard(jobId) {
+        activeProgress = undefined;
+        activeTransfer = false;
+        await native.discard(jobId);
+      },
+      async cancel(jobId) {
+        activeProgress = undefined;
+        activeTransfer = false;
+        await native.cancel(jobId);
+      },
+    };
+    return createMediaAcquirer(adapter);
+  })();
+
+  return installedAcquirer;
+}

--- a/src/lib/nostr/forgeSong.ts
+++ b/src/lib/nostr/forgeSong.ts
@@ -1,0 +1,57 @@
+import type { NostrEvent } from "applesauce-core/helpers/event";
+import {
+  buildSongAudioUpdateTemplate,
+  buildSongTemplateFromMetadata,
+  parseSongEvent,
+  type ParsedSong,
+  type SongMetadataInput,
+} from "./domain";
+import type { EventTemplate } from "./types";
+
+type UploadedMedia = {
+  url: string;
+};
+
+type ForgeAndFavoriteSongInput = {
+  song?: ParsedSong;
+  metadata?: SongMetadataInput;
+  videoId: string;
+  favorite: (address: string) => Promise<unknown>;
+  acquireMedia: () => Promise<UploadedMedia>;
+  publish: (template: EventTemplate) => Promise<NostrEvent>;
+};
+
+/**
+ * Persist a song in the user's crate before starting its media transfer, then
+ * update that same addressable song event with the uploaded Blossom URL.
+ */
+export async function forgeAndFavoriteSong(
+  input: ForgeAndFavoriteSongInput,
+): Promise<ParsedSong> {
+  let persistedSong = input.song;
+  if (!persistedSong) {
+    if (!input.metadata) {
+      throw new Error("Track metadata disappeared before the download started.");
+    }
+    const event = await input.publish(
+      buildSongTemplateFromMetadata(input.metadata),
+    );
+    persistedSong = parseSongEvent(event);
+  }
+
+  if (!persistedSong.address) {
+    throw new Error("The song has no canonical address to add to the crate.");
+  }
+
+  await input.favorite(persistedSong.address);
+  const uploaded = await input.acquireMedia();
+  const updatedEvent = await input.publish(
+    buildSongAudioUpdateTemplate(
+      persistedSong.event,
+      uploaded.url,
+      input.videoId,
+    ),
+  );
+
+  return parseSongEvent(updatedEvent);
+}

--- a/src/lib/nostr/nip46.ts
+++ b/src/lib/nostr/nip46.ts
@@ -1,0 +1,19 @@
+import type { Platform } from "../platform";
+
+const PLATFORM_LABELS: Record<Platform, string> = {
+  web: "Web",
+  android: "Android",
+  macos: "macOS",
+  windows: "Windows",
+  linux: "Linux",
+  ios: "iOS",
+  unknown: "App",
+};
+
+export function nip46ClientName(
+  platform: Platform,
+  production = process.env.NODE_ENV === "production",
+): string {
+  const appName = production ? "Wavefunc Radio" : "Wavefunc Radio DEV";
+  return `${appName} · ${PLATFORM_LABELS[platform]}`;
+}

--- a/src/routes/crate.tsx
+++ b/src/routes/crate.tsx
@@ -7,7 +7,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { getAppDataRelayUrls } from "../config/nostr";
 import { useCurrentAccount } from "../lib/nostr/auth";
 import {
-  buildSongAudioUpdateTemplate,
   getSongListSongCount,
   parseSongEvent,
   SONG_KIND,
@@ -17,27 +16,10 @@ import {
 } from "../lib/nostr/domain";
 import { useSongFavorites } from "../lib/hooks/useSongFavorites";
 import { useWavefuncNostr } from "../lib/nostr/runtime";
-import {
-  getMetadataClient,
-  type DownloadFormat,
-  type YouTubeResult,
-} from "../ctxcn/WavefuncMetadataServerClient";
+import { requestEventsIntoStore } from "../lib/nostr/requestEvents";
 import { ShareSongDialog } from "../components/ShareSongDialog";
-import { YoutubeEmbed } from "../components/YoutubeEmbed";
-import { useUIStore } from "../stores/uiStore";
+import { SongMediaDialog } from "../components/SongMediaDialog";
 import { cn } from "@/lib/utils";
-
-const VIDEO_FORMATS: { label: string; format: DownloadFormat; icon: string; hint: string }[] = [
-  { label: "360p", format: "360p", icon: "video_file", hint: "WebM ≈10–30 MB" },
-  { label: "480p", format: "480p", icon: "video_file", hint: "WebM ≈20–60 MB" },
-  { label: "720p", format: "720p", icon: "video_file", hint: "MP4 ≈80–200 MB" },
-];
-
-const BLOSSOM_SERVERS = [
-  { label: "blossom.band", url: "https://blossom.band" },
-  { label: "cdn.hzrd149.com", url: "https://cdn.hzrd149.com" },
-  { label: "files.v0l.io", url: "https://files.v0l.io" },
-];
 
 export const Route = createFileRoute("/crate")({
   component: Crate,
@@ -70,14 +52,35 @@ function useSongsFromList(list: ParsedSongList): {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(addresses)]);
 
-  // Active relay subscription so song events stream into the store.
+  // A bounded historical request releases the loading state at completion,
+  // even if a referenced song was deleted or is temporarily unavailable.
+  // The separate live subscription keeps resolved songs fresh afterwards.
+  const [initialLoadComplete, setInitialLoadComplete] = useState(false);
   useEffect(() => {
-    if (filters.length === 0) return;
-    const subscription = relayPool
+    if (filters.length === 0) {
+      setInitialLoadComplete(true);
+      return;
+    }
+
+    setInitialLoadComplete(false);
+    const requestSubscription = requestEventsIntoStore(
+      relayPool,
+      eventStore,
+      getAppDataRelayUrls(),
+      filters,
+    ).subscribe({
+      complete: () => setInitialLoadComplete(true),
+      error: () => setInitialLoadComplete(true),
+    });
+    const liveSubscription = relayPool
       .subscription(getAppDataRelayUrls(), filters)
       .pipe(storeEvents(eventStore))
       .subscribe();
-    return () => subscription.unsubscribe();
+
+    return () => {
+      requestSubscription.unsubscribe();
+      liveSubscription.unsubscribe();
+    };
   }, [eventStore, relayPool, filters]);
 
   // Reactive timeline read from the canonical model.
@@ -94,7 +97,7 @@ function useSongsFromList(list: ParsedSongList): {
 
   return {
     songs,
-    isLoading: addresses.length > 0 && songs.length < addresses.length,
+    isLoading: addresses.length > 0 && !initialLoadComplete,
   };
 }
 
@@ -104,270 +107,6 @@ function formatDuration(seconds: number): string {
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
-}
-
-// ─── YouTube audio panel ─────────────────────────────────────────────────────
-
-interface YouTubeAudioPanelProps {
-  song: ParsedSong;
-  onClose: () => void;
-}
-
-function YouTubeAudioPanel({ song, onClose }: YouTubeAudioPanelProps) {
-  const { isLoggedIn } = useSongFavorites();
-  const pulseLogin = useUIStore((s) => s.pulseLogin);
-  const { signer, signAndPublish } = useWavefuncNostr();
-  const [phase, setPhase] = useState<"searching" | "results" | "downloading" | "uploading" | "error">("searching");
-  const [results, setResults] = useState<YouTubeResult[]>([]);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const [downloadingId, setDownloadingId] = useState<string | null>(null);
-  const [progressMsg, setProgressMsg] = useState<string | null>(null);
-  const [watchingId, setWatchingId] = useState<string | null>(null);
-  const [blossomUrl, setBlossomUrl] = useState(BLOSSOM_SERVERS[0]!.url);
-  const [customBlossom, setCustomBlossom] = useState("");
-  const [showCustom, setShowCustom] = useState(false);
-
-  const effectiveBlossomUrl = showCustom ? customBlossom : blossomUrl;
-
-  useEffect(() => {
-    if (!isLoggedIn) {
-      pulseLogin();
-      onClose();
-      return;
-    }
-    const query = [song.title, song.artist].filter(Boolean).join(" ");
-    getMetadataClient()
-      .SearchYouTube(query, 5)
-      .then((out) => {
-        setResults(out.results);
-        setPhase("results");
-      })
-      .catch((err) => {
-        setErrorMsg(err.message ?? "Search failed");
-        setPhase("error");
-      });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleDownload = async (result: YouTubeResult, format: DownloadFormat) => {
-    if (!isLoggedIn) {
-      pulseLogin();
-      return;
-    }
-    if (!signer) {
-      setErrorMsg("No signer available — connect your account first");
-      setPhase("error");
-      return;
-    }
-
-    setDownloadingId(result.videoId);
-    setProgressMsg(null);
-    setPhase("downloading");
-
-    try {
-      // Step 1: server downloads the file and returns hash
-      const { tempId, sha256 } = await getMetadataClient().PrepareDownload(
-        result.videoId,
-        format,
-        (p) => setProgressMsg(p.message ?? null),
-      );
-
-      // Step 2: client signs BUD-01 kind 24242 auth event
-      setPhase("uploading");
-      setProgressMsg("Waiting for signature...");
-      const now = Math.floor(Date.now() / 1000);
-      const authTemplate = {
-        kind: 24242,
-        content: `Upload ${format}`,
-        created_at: now,
-        tags: [
-          ["t", "upload"],
-          ["x", sha256],
-          ["expiration", String(now + 600)],
-        ] as string[][],
-      };
-      const authEvent = await signer.signEvent(authTemplate);
-      const signedEventJson = JSON.stringify(authEvent);
-
-      // Step 3: server uploads using our signed auth
-      setProgressMsg("Uploading to Blossom...");
-      const { url } = await getMetadataClient().UploadToBlossom(
-        tempId,
-        effectiveBlossomUrl,
-        signedEventJson,
-        (p) => setProgressMsg(p.message ?? null),
-      );
-
-      // Step 4: publish updated song event with the new audio URL attached
-      const updateTemplate = buildSongAudioUpdateTemplate(
-        song.event,
-        url,
-        result.videoId,
-      );
-      await signAndPublish(updateTemplate);
-
-      onClose();
-    } catch (err: any) {
-      setErrorMsg(err.message ?? "Download failed");
-      setPhase("error");
-      setDownloadingId(null);
-    }
-  };
-
-  if (watchingId) {
-    return <YoutubeEmbed videoId={watchingId} onClose={() => setWatchingId(null)} />;
-  }
-
-  return (
-    <div className="border-t-2 border-on-background/10 bg-surface-container-high px-4 py-3 space-y-2">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <span className="text-[9px] font-black uppercase tracking-widest text-on-background/50 flex items-center gap-1.5">
-          <span className="material-symbols-outlined text-[12px]">smart_display</span>
-          {phase === "searching" && "SEARCHING..."}
-          {phase === "results" && `RESULTS_FOR: ${[song.title, song.artist].filter(Boolean).join(" — ")}`}
-          {(phase === "downloading" || phase === "uploading") && "SAVING_TO_BLOSSOM..."}
-          {phase === "error" && "ERROR"}
-        </span>
-        <button onClick={onClose} className="text-on-background/30 hover:text-on-background transition-colors">
-          <span className="material-symbols-outlined text-[14px]">close</span>
-        </button>
-      </div>
-
-      {/* Blossom server picker (only in results phase) */}
-      {phase === "results" && (
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-[9px] font-bold uppercase tracking-widest text-on-background/40 shrink-0">BLOSSOM:</span>
-          {BLOSSOM_SERVERS.map((s) => (
-            <button
-              key={s.url}
-              onClick={() => { setBlossomUrl(s.url); setShowCustom(false); }}
-              className={cn(
-                "text-[9px] font-black uppercase tracking-widest px-2 py-0.5 border transition-colors",
-                !showCustom && blossomUrl === s.url
-                  ? "border-on-background bg-on-background text-surface"
-                  : "border-on-background/20 hover:border-on-background/60",
-              )}
-            >
-              {s.label}
-            </button>
-          ))}
-          <button
-            onClick={() => setShowCustom((v) => !v)}
-            className={cn(
-              "text-[9px] font-black uppercase tracking-widest px-2 py-0.5 border transition-colors",
-              showCustom
-                ? "border-on-background bg-on-background text-surface"
-                : "border-on-background/20 hover:border-on-background/60",
-            )}
-          >
-            CUSTOM
-          </button>
-          {showCustom && (
-            <input
-              type="url"
-              value={customBlossom}
-              onChange={(e) => setCustomBlossom(e.target.value)}
-              placeholder="https://your-blossom-server.com"
-              className="flex-1 min-w-[200px] bg-transparent text-[9px] font-mono border-b border-on-background/40 outline-none py-0.5 placeholder:text-on-background/25"
-            />
-          )}
-        </div>
-      )}
-
-      {phase === "searching" && (
-        <div className="flex items-center gap-2 py-3 text-on-background/40">
-          <span className="material-symbols-outlined text-[16px]" style={{ animation: "spin 0.8s linear infinite" }}>sync</span>
-          <span className="text-[10px] font-bold uppercase tracking-widest">FETCHING_RESULTS...</span>
-        </div>
-      )}
-
-      {phase === "results" && results.length === 0 && (
-        <p className="text-[10px] text-on-background/40 uppercase tracking-widest py-3">NO_RESULTS_FOUND</p>
-      )}
-
-      {phase === "results" && results.length > 0 && (
-        <div className="space-y-1">
-          {results.map((r) => {
-            const isDownloading = downloadingId === r.videoId;
-            return (
-              <div key={r.videoId} className="flex items-center gap-2.5 px-2 py-1.5 border border-transparent hover:border-on-background/20">
-                {r.thumbnailUrl && (
-                  <img src={r.thumbnailUrl} alt="" className="w-12 h-9 object-cover shrink-0 bg-on-background/10"
-                    onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }} />
-                )}
-                <div className="flex-1 min-w-0">
-                  <p className="text-[11px] font-bold uppercase tracking-tight truncate">{r.title}</p>
-                  <p className="text-[9px] text-on-background/50 truncate">
-                    {r.channel}
-                    {r.duration && <span className="ml-2 tabular-nums">{formatDuration(r.duration)}</span>}
-                  </p>
-                </div>
-                <button
-                  onClick={() => setWatchingId(r.videoId)}
-                  disabled={downloadingId !== null}
-                  className="shrink-0 flex items-center gap-1 px-2 py-1 text-[9px] font-black uppercase tracking-widest border border-on-background/20 hover:bg-on-background hover:text-surface hover:border-on-background transition-colors disabled:opacity-40"
-                  title="Preview"
-                >
-                  <span className="material-symbols-outlined text-[12px]">play_arrow</span>
-                  PREVIEW
-                </button>
-                <button
-                  onClick={() => handleDownload(r, "audio")}
-                  disabled={downloadingId !== null}
-                  className="shrink-0 flex items-center gap-1 px-2 py-1 text-[9px] font-black uppercase tracking-widest border border-on-background/20 hover:bg-on-background hover:text-surface hover:border-on-background transition-colors disabled:opacity-40"
-                  title="Save audio to Blossom"
-                >
-                  <span className="material-symbols-outlined text-[12px]"
-                    style={isDownloading ? { animation: "spin 0.8s linear infinite" } : {}}>
-                    {isDownloading ? "sync" : "audio_file"}
-                  </span>
-                  AUDIO
-                </button>
-                {VIDEO_FORMATS.map(({ label, format, hint }) => (
-                  <button
-                    key={format}
-                    onClick={() => handleDownload(r, format)}
-                    disabled={downloadingId !== null}
-                    className="shrink-0 flex items-center gap-1 px-2 py-1 text-[9px] font-black uppercase tracking-widest border border-on-background/20 hover:bg-on-background hover:text-surface hover:border-on-background transition-colors disabled:opacity-40"
-                    title={hint}
-                  >
-                    <span className="material-symbols-outlined text-[12px]">video_file</span>
-                    {label}
-                  </button>
-                ))}
-              </div>
-            );
-          })}
-        </div>
-      )}
-
-      {(phase === "downloading" || phase === "uploading") && (
-        <div className="flex items-start gap-2 py-3 text-on-background/60">
-          <span className="material-symbols-outlined text-[16px] shrink-0 mt-0.5" style={{ animation: "spin 0.8s linear infinite" }}>sync</span>
-          <div className="min-w-0">
-            <p className="text-[10px] font-bold uppercase tracking-widest">
-              {phase === "uploading" ? "UPLOADING_TO_BLOSSOM..." : "DOWNLOADING..."}
-            </p>
-            <p className="text-[9px] text-on-background/50 mt-0.5 truncate font-mono">{progressMsg ?? "Starting..."}</p>
-          </div>
-        </div>
-      )}
-
-      {phase === "error" && (
-        <div className="flex items-center gap-2 py-2 text-destructive">
-          <span className="material-symbols-outlined text-[14px]">error</span>
-          <p className="text-[10px] font-bold uppercase tracking-tight truncate">{errorMsg}</p>
-          <button
-            onClick={() => { setPhase("results"); setErrorMsg(null); setDownloadingId(null); }}
-            className="ml-auto shrink-0 text-[9px] font-black uppercase tracking-widest border border-current px-2 py-0.5 hover:bg-destructive hover:text-white transition-colors"
-          >
-            RETRY
-          </button>
-        </div>
-      )}
-    </div>
-  );
 }
 
 // ─── Song row ─────────────────────────────────────────────────────────────────
@@ -383,7 +122,7 @@ interface SongRowProps {
 function SongRow({ song, sourceList, otherLists, onMove, onRemove }: SongRowProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [ytPanelOpen, setYtPanelOpen] = useState(false);
+  const [mediaDialogOpen, setMediaDialogOpen] = useState(false);
   const [embedOpen, setEmbedOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -475,18 +214,16 @@ function SongRow({ song, sourceList, otherLists, onMove, onRemove }: SongRowProp
         </button>
       )}
 
-      {/* Get audio */}
+      {/* Save audio or video */}
       <button
-        onClick={(e) => { e.stopPropagation(); setYtPanelOpen((v) => !v); }}
+        onClick={(e) => { e.stopPropagation(); setMediaDialogOpen(true); }}
         className={cn(
           "shrink-0 transition-colors",
           song.audioUrl ? "text-primary/60 hover:text-primary" : "text-on-background/30 hover:text-on-background",
         )}
-        title={song.audioUrl ? "Audio attached — replace?" : "Get audio"}
+        title={song.audioUrl ? "Save another copy to Blossom" : "Save audio or video to Blossom"}
       >
-        <span className="material-symbols-outlined text-[16px]">
-          {song.audioUrl ? "audio_file" : "download"}
-        </span>
+        <span className="material-symbols-outlined text-[16px]">auto_fix_high</span>
       </button>
 
       {/* Share */}
@@ -546,8 +283,8 @@ function SongRow({ song, sourceList, otherLists, onMove, onRemove }: SongRowProp
         </div>
       )}
     </div>
-    {ytPanelOpen && (
-      <YouTubeAudioPanel song={song} onClose={() => setYtPanelOpen(false)} />
+    {mediaDialogOpen && (
+      <SongMediaDialog song={song} onClose={() => setMediaDialogOpen(false)} />
     )}
     {shareOpen && (
       <ShareSongDialog song={song} onClose={() => setShareOpen(false)} />
@@ -628,7 +365,7 @@ function SongListPanel({ list, allLists, onMove, onRemove }: SongListPanelProps)
         </div>
       ) : (
         <div className="px-4 py-4 text-[10px] text-on-background/40 uppercase tracking-widest text-center">
-          LOADING_TRACKS...
+          TRACKS_CURRENTLY_UNAVAILABLE
         </div>
       )}
     </div>

--- a/tests/android-playback-contract.test.ts
+++ b/tests/android-playback-contract.test.ts
@@ -81,6 +81,17 @@ describe("Android playback release contract", () => {
     expect(environment).toContain('return "wss://relay.wavefunc.live"');
   });
 
+  test("keeps tappable web content outside Android system bars", () => {
+    const androidBuild = read("src-tauri/android-template/build.gradle.kts");
+    const activity = read("src-tauri/android-template/MainActivity.kt");
+
+    expect(androidBuild).toContain("syncWavefuncMainActivity");
+    expect(activity).toContain("WindowInsetsCompat.Type.systemBars()");
+    expect(activity).toContain("WindowInsetsCompat.Type.displayCutout()");
+    expect(activity).toContain("ViewCompat.setOnApplyWindowInsetsListener");
+    expect(activity).toContain("WindowInsetsCompat.CONSUMED");
+  });
+
   test("routes Android playback and live metadata through the native backend", () => {
     const bridge = read("src/lib/nativePlayback.ts");
     const store = read("src/stores/playerStore.ts");

--- a/tests/forge-song.test.ts
+++ b/tests/forge-song.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import { finalizeEvent, getPublicKey } from "nostr-tools/pure";
+import { forgeAndFavoriteSong } from "../src/lib/nostr/forgeSong";
+import {
+  getSongAddressForPubkey,
+  parseSongEvent,
+  SONG_KIND,
+} from "../src/lib/nostr/domain";
+
+const key = new Uint8Array(32).fill(7);
+
+function songEvent() {
+  return finalizeEvent(
+    {
+      kind: SONG_KIND,
+      created_at: 1,
+      content: "",
+      tags: [
+        ["d", "dreamwaves-by-vogel"],
+        ["title", "Dreamwaves"],
+        ["c", "Vogel", "artist"],
+      ],
+    },
+    key,
+  );
+}
+
+describe("forged song persistence", () => {
+  test("favourites an existing song before acquiring its media", async () => {
+    const calls: string[] = [];
+    const source = parseSongEvent(songEvent());
+
+    const result = await forgeAndFavoriteSong({
+      song: source,
+      videoId: "RSOA00NFs7k",
+      async favorite(address) {
+        calls.push(`favorite:${address}`);
+      },
+      async acquireMedia() {
+        calls.push("acquire");
+        return { url: "https://blossom.example/dreamwaves.mp4" };
+      },
+      async publish(template) {
+        calls.push("publish-update");
+        return finalizeEvent(
+          { ...template, created_at: 2 },
+          key,
+        );
+      },
+    });
+
+    expect(calls).toEqual([
+      `favorite:${source.address}`,
+      "acquire",
+      "publish-update",
+    ]);
+    expect(result.address).toBe(source.address);
+    expect(result.audioUrl).toBe("https://blossom.example/dreamwaves.mp4");
+    expect(result.youtubeId).toBe("RSOA00NFs7k");
+  });
+
+  test("publishes a new song, favourites it, then acquires its media", async () => {
+    const calls: string[] = [];
+    const expectedAddress = getSongAddressForPubkey(
+      "dreamwaves-by-vogel",
+      getPublicKey(key),
+    );
+    let publishedAt = 1;
+
+    const result = await forgeAndFavoriteSong({
+      metadata: { song: "Dreamwaves", artist: "Vogel" },
+      videoId: "RSOA00NFs7k",
+      async favorite(address) {
+        calls.push(`favorite:${address}`);
+      },
+      async acquireMedia() {
+        calls.push("acquire");
+        return { url: "https://blossom.example/dreamwaves.mp4" };
+      },
+      async publish(template) {
+        const isUpdate = template.tags.some((tag) => tag[0] === "r");
+        calls.push(isUpdate ? "publish-update" : "publish-base");
+        return finalizeEvent(
+          { ...template, created_at: publishedAt++ },
+          key,
+        );
+      },
+    });
+
+    expect(calls).toEqual([
+      "publish-base",
+      `favorite:${expectedAddress}`,
+      "acquire",
+      "publish-update",
+    ]);
+    expect(result.address).toBe(expectedAddress);
+    expect(result.audioUrl).toBe("https://blossom.example/dreamwaves.mp4");
+  });
+
+  test("keeps the favourite when media acquisition fails", async () => {
+    const calls: string[] = [];
+    const source = parseSongEvent(songEvent());
+
+    await expect(
+      forgeAndFavoriteSong({
+        song: source,
+        videoId: "RSOA00NFs7k",
+        async favorite(address) {
+          calls.push(`favorite:${address}`);
+        },
+        async acquireMedia() {
+          calls.push("acquire");
+          throw new Error("Download was blocked");
+        },
+        async publish() {
+          calls.push("publish-update");
+          throw new Error("The update must not be published");
+        },
+      }),
+    ).rejects.toThrow("Download was blocked");
+
+    expect(calls).toEqual([`favorite:${source.address}`, "acquire"]);
+  });
+});

--- a/tests/media-acquisition-contract.test.ts
+++ b/tests/media-acquisition-contract.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("installed-app media acquisition contract", () => {
+  test("shares one responsive media dialog between Crate and now playing", () => {
+    const crate = read("src/routes/crate.tsx");
+    const player = read("src/components/FloatingPlayer.tsx");
+    const dialogPath = join(root, "src/components/SongMediaDialog.tsx");
+
+    expect(existsSync(dialogPath)).toBe(true);
+    if (!existsSync(dialogPath)) return;
+    const dialog = read("src/components/SongMediaDialog.tsx");
+
+    expect(crate).toContain("SongMediaDialog");
+    expect(player).toContain("SongMagicButton");
+    expect(dialog).toContain("mediaAcquisitionAvailability(platform)");
+    expect(dialog).toContain("createInstalledMediaAcquirer()");
+    expect(dialog).toContain("ShareSongDialog");
+    expect(dialog).toContain("forgeAndFavoriteSong");
+    expect(dialog).toContain("addToDefaultList(address)");
+    expect(dialog).toContain("setShareSong(persistedSong)");
+    expect(dialog).toContain("WAITING_FOR_SIGNER_APPROVAL");
+    expect(dialog).toContain('DEFAULT_BLOSSOM_URL = "https://blossom.band"');
+    expect(dialog).toContain("grid-cols-2");
+    expect(dialog).toContain("break-words");
+    expect(dialog).toContain('href="/apps"');
+    expect(crate).not.toContain(".PrepareDownload(");
+    expect(crate).not.toContain(".UploadToBlossom(");
+    expect(crate).not.toContain("VIDEO_FORMATS.map");
+  });
+
+  test("ships yt-dlp and a supported JS challenge runtime in desktop releases", () => {
+    const config = read("src-tauri/tauri.conf.json");
+    const workflow = read(".github/workflows/release.yml");
+    const desktop = read("src-tauri/plugins/media-acquisition/src/desktop.rs");
+
+    expect(config).toContain('"resources/bin/*": "bin/"');
+    expect(workflow).toContain("Prepare desktop media engine");
+    expect(workflow).toContain("yt-dlp_macos");
+    expect(workflow).toContain("yt-dlp_linux");
+    expect(workflow).toContain("yt-dlp.exe");
+    expect(workflow).toContain("deno-aarch64-apple-darwin.zip");
+    expect(desktop).toContain("WAVEFUNC_DENO_PATH");
+    expect(desktop).toContain('format!("deno:{}"');
+  });
+
+  test("keeps Android downloads alive with its embedded native engine", () => {
+    const appBuild = read("src-tauri/android-template/build.gradle.kts");
+    const build = read(
+      "src-tauri/plugins/media-acquisition/android/build.gradle.kts",
+    );
+    const manifest = read(
+      "src-tauri/plugins/media-acquisition/android/src/main/AndroidManifest.xml",
+    );
+    const plugin = read(
+      "src-tauri/plugins/media-acquisition/android/src/main/java/live/wavefunc/media/WavefuncMediaPlugin.kt",
+    );
+
+    expect(build).toContain("youtubedl-android:library:0.18.1");
+    expect(build).toContain("youtubedl-android:ffmpeg:0.18.1");
+    expect(build).toContain('bundledYtDlpVersion = "2026.07.04"');
+    expect(build).toContain(
+      'bundledYtDlpSha256 = "495be29ff4d9d4e9be7eabdfef225221e5d5282e77f2f505abc6dca80349f3fd"',
+    );
+    expect(build).toContain("prepareBundledYtDlp");
+    expect(manifest).toContain("android.permission.FOREGROUND_SERVICE_DATA_SYNC");
+    expect(manifest).toContain('android:foregroundServiceType="dataSync"');
+    expect(manifest).toContain('android:extractNativeLibs="true"');
+    expect(appBuild).toContain("jniLibs.useLegacyPackaging = true");
+    expect(plugin).toContain("YoutubeDL.execute(request, jobId)");
+    expect(plugin).toContain("fun status(invoke: Invoke)");
+    expect(plugin).toContain('response.put("state", "prepared")');
+    expect(plugin).toContain("preparingJobs");
+    expect(plugin).toContain("YoutubeDL.UpdateChannel.STABLE");
+    expect(plugin).toContain("refreshYtDlpIfNeeded");
+    expect(plugin).toContain('message.contains("HTTP Error 403")');
+    expect(plugin).toContain('"360p" -> videoFormatSelector(360)');
+    expect(plugin).toContain(
+      "bestvideo[height<=$height][ext=mp4]+bestaudio[ext=m4a]",
+    );
+    expect(plugin).toContain("X-SHA-256");
+    expect(plugin).toContain("Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING");
+  });
+
+  test("desktop video downloads use the same split-stream fallback", () => {
+    const desktop = read("src-tauri/plugins/media-acquisition/src/desktop.rs");
+
+    expect(desktop).toContain(
+      "bestvideo[height<=360][ext=mp4]+bestaudio[ext=m4a]",
+    );
+    expect(desktop).toContain("bestvideo[height<=720]+bestaudio");
+  });
+});

--- a/tests/media-acquisition-contract.test.ts
+++ b/tests/media-acquisition-contract.test.ts
@@ -67,6 +67,10 @@ describe("installed-app media acquisition contract", () => {
       'bundledYtDlpSha256 = "495be29ff4d9d4e9be7eabdfef225221e5d5282e77f2f505abc6dca80349f3fd"',
     );
     expect(build).toContain("prepareBundledYtDlp");
+    expect(build).toContain("prepareYoutubedlAndroidLicense");
+    expect(build).toContain(
+      "raw.githubusercontent.com/yausername/youtubedl-android/0.18.1/LICENSE",
+    );
     expect(manifest).toContain("android.permission.FOREGROUND_SERVICE_DATA_SYNC");
     expect(manifest).toContain('android:foregroundServiceType="dataSync"');
     expect(manifest).toContain('android:extractNativeLibs="true"');
@@ -84,6 +88,16 @@ describe("installed-app media acquisition contract", () => {
     );
     expect(plugin).toContain("X-SHA-256");
     expect(plugin).toContain("Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING");
+  });
+
+  test("publishes the Android downloader license and corresponding source", () => {
+    const workflow = read(".github/workflows/release.yml");
+
+    expect(workflow).toContain("youtubedl-android-0.18.1-source.tar.gz");
+    expect(workflow).toContain("GPL-3.0-youtubedl-android.txt");
+    expect(workflow).toContain(
+      "08833449d671142c34325203cbfcca31c4fa668a0c4b8c0c31a2e4354ce11b98",
+    );
   });
 
   test("desktop video downloads use the same split-stream fallback", () => {

--- a/tests/media-acquisition.test.ts
+++ b/tests/media-acquisition.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createMediaAcquirer,
+  createTauriMediaAdapter,
+  mediaAcquisitionAvailability,
+  type NativeMediaAdapter,
+} from "../src/lib/mediaAcquisition";
+import { platformInfo } from "../src/lib/platform";
+
+describe("client media acquisition", () => {
+  test("uses local acquisition in installed desktop and Android apps", () => {
+    expect(mediaAcquisitionAvailability(platformInfo("android", true))).toEqual({
+      mode: "local",
+    });
+    expect(mediaAcquisitionAvailability(platformInfo("macos", true))).toEqual({
+      mode: "local",
+    });
+    expect(mediaAcquisitionAvailability(platformInfo("windows", true))).toEqual({
+      mode: "local",
+    });
+    expect(mediaAcquisitionAvailability(platformInfo("linux", true))).toEqual({
+      mode: "local",
+    });
+  });
+
+  test("directs web and unsupported native platforms to a supported app", () => {
+    expect(mediaAcquisitionAvailability(platformInfo("web", false))).toEqual({
+      mode: "app-required",
+      reason: "Install WaveFunc for Android or desktop to save media locally.",
+    });
+    expect(mediaAcquisitionAvailability(platformInfo("ios", true))).toEqual({
+      mode: "app-required",
+      reason: "Install WaveFunc for Android or desktop to save media locally.",
+    });
+  });
+
+  test("authorizes the prepared hash for only the selected Blossom server", async () => {
+    const calls: { auth?: any; upload?: any } = {};
+    const adapter: NativeMediaAdapter = {
+      async prepare() {
+        return {
+          jobId: "job-1",
+          sha256: "abc123",
+          size: 42,
+          mimeType: "audio/webm",
+        };
+      },
+      async upload(payload) {
+        calls.upload = payload;
+        return {
+          url: "https://blossom.example/abc123",
+          sha256: "abc123",
+          size: 42,
+          mimeType: "audio/webm",
+        };
+      },
+      async discard() {},
+      async cancel() {},
+    };
+    const acquirer = createMediaAcquirer(adapter, () => 1_700_000_000);
+
+    const saved = await acquirer.save({
+      videoId: "dQw4w9WgXcQ",
+      format: "audio",
+      blossomUrl: "https://Blossom.Example/upload",
+      async signEvent(template) {
+        calls.auth = template;
+        return { ...template, id: "signed", pubkey: "pubkey", sig: "sig" };
+      },
+    });
+
+    expect(calls.auth).toMatchObject({
+      kind: 24242,
+      created_at: 1_700_000_000,
+      tags: [
+        ["t", "upload"],
+        ["x", "abc123"],
+        ["expiration", "1700000600"],
+        ["server", "blossom.example"],
+      ],
+    });
+    expect(calls.upload).toEqual({
+      jobId: "job-1",
+      blossomUrl: "https://blossom.example/upload",
+      signedAuthEvent: JSON.stringify({
+        ...calls.auth,
+        id: "signed",
+        pubkey: "pubkey",
+        sig: "sig",
+      }),
+    });
+    expect(saved.url).toBe("https://blossom.example/abc123");
+  });
+
+  test("discards the local file if signing or upload fails", async () => {
+    const discarded: string[] = [];
+    const adapter: NativeMediaAdapter = {
+      async prepare() {
+        return {
+          jobId: "job-to-clean",
+          sha256: "deadbeef",
+          size: 10,
+          mimeType: "video/mp4",
+        };
+      },
+      async upload() {
+        throw new Error("upload failed");
+      },
+      async discard(jobId) {
+        discarded.push(jobId);
+      },
+      async cancel() {},
+    };
+
+    await expect(
+      createMediaAcquirer(adapter).save({
+        videoId: "dQw4w9WgXcQ",
+        format: "720p",
+        blossomUrl: "https://blossom.example",
+        async signEvent(template) {
+          return template;
+        },
+      }),
+    ).rejects.toThrow("upload failed");
+
+    expect(discarded).toEqual(["job-to-clean"]);
+  });
+
+  test("shows signer approval and times out instead of displaying stale download progress forever", async () => {
+    const stages: string[] = [];
+    const discarded: string[] = [];
+    const adapter: NativeMediaAdapter = {
+      async prepare() {
+        return {
+          jobId: "pixel-signer-job",
+          sha256: "pixel-signer-hash",
+          size: 42,
+          mimeType: "video/mp4",
+        };
+      },
+      async upload() {
+        throw new Error("must not upload without authorization");
+      },
+      async discard(jobId) {
+        discarded.push(jobId);
+      },
+      async cancel() {},
+    };
+
+    const outcome = await Promise.race([
+      createMediaAcquirer(
+        adapter,
+        () => 1_700_000_000,
+        5,
+      ).save({
+        videoId: "dQw4w9WgXcQ",
+        format: "360p",
+        blossomUrl: "https://blossom.example",
+        signEvent: () => new Promise(() => undefined),
+        onProgress: ({ stage }) => stages.push(stage),
+      }).then(
+        () => "unexpected-success",
+        (error) => (error as Error).message,
+      ),
+      new Promise<"test-timeout">((resolve) =>
+        setTimeout(() => resolve("test-timeout"), 50),
+      ),
+    ]);
+
+    expect(outcome).toContain("Signer approval timed out");
+    expect(stages).toContain("authorizing");
+    expect(discarded).toEqual(["pixel-signer-job"]);
+  });
+
+  test("rejects malformed video IDs before invoking native code", async () => {
+    let prepared = false;
+    const adapter: NativeMediaAdapter = {
+      async prepare() {
+        prepared = true;
+        throw new Error("must not run");
+      },
+      async upload() {
+        throw new Error("must not run");
+      },
+      async discard() {},
+      async cancel() {},
+    };
+
+    await expect(
+      createMediaAcquirer(adapter).save({
+        videoId: "https://example.com/not-a-video",
+        format: "audio",
+        blossomUrl: "https://blossom.example",
+        async signEvent(template) {
+          return template;
+        },
+      }),
+    ).rejects.toThrow("Invalid YouTube video ID");
+    expect(prepared).toBe(false);
+  });
+
+  test("maps the shared adapter to the narrow Tauri plugin commands", async () => {
+    const calls: Array<[string, unknown]> = [];
+    const invoke = async <T>(command: string, args?: unknown): Promise<T> => {
+      calls.push([command, args]);
+      if (command.endsWith("|prepare")) {
+        return {
+          jobId: "job-2",
+          sha256: "hash",
+          size: 99,
+          mimeType: "audio/webm",
+        } as T;
+      }
+      if (command.endsWith("|upload")) {
+        return {
+          url: "https://blossom.example/hash",
+          sha256: "hash",
+          size: 99,
+          mimeType: "audio/webm",
+        } as T;
+      }
+      return undefined as T;
+    };
+    const adapter = createTauriMediaAdapter(invoke, {
+      createJobId: () => "job-2",
+    });
+
+    await adapter.prepare({ videoId: "dQw4w9WgXcQ", format: "audio" });
+    await adapter.upload({
+      jobId: "job-2",
+      blossomUrl: "https://blossom.example/",
+      signedAuthEvent: "{}",
+    });
+    await adapter.discard("job-2");
+    await adapter.cancel("job-3");
+
+    expect(calls).toEqual([
+      [
+        "plugin:wavefunc-media|prepare",
+        {
+          payload: {
+            videoId: "dQw4w9WgXcQ",
+            format: "audio",
+            jobId: "job-2",
+          },
+        },
+      ],
+      [
+        "plugin:wavefunc-media|upload",
+        {
+          payload: {
+            jobId: "job-2",
+            blossomUrl: "https://blossom.example/",
+            signedAuthEvent: "{}",
+          },
+        },
+      ],
+      ["plugin:wavefunc-media|discard", { jobId: "job-2" }],
+      ["plugin:wavefunc-media|cancel", { jobId: "job-3" }],
+    ]);
+  });
+
+  test("recovers a completed preparation when the one-shot native response is lost", async () => {
+    const prepared = {
+      jobId: "pixel-background-job",
+      sha256: "pixel-hash",
+      size: 5_209_456,
+      mimeType: "video/mp4",
+    };
+    const neverResolves = new Promise<never>(() => undefined);
+    let statusChecks = 0;
+    let prepareArgs: unknown;
+    const invoke = async <T>(command: string, args?: unknown): Promise<T> => {
+      if (command.endsWith("|prepare")) {
+        prepareArgs = args;
+        return neverResolves;
+      }
+      if (command.endsWith("|status")) {
+        statusChecks += 1;
+        return (statusChecks === 1
+          ? { state: "preparing" }
+          : { state: "prepared", media: prepared }) as T;
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    };
+    const adapter = createTauriMediaAdapter(invoke, {
+      createJobId: () => prepared.jobId,
+      pollIntervalMs: 0,
+    });
+
+    const result = await Promise.race([
+      adapter.prepare({ videoId: "dQw4w9WgXcQ", format: "360p" }),
+      new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 50)),
+    ]);
+
+    expect(result).toEqual(prepared);
+    expect(statusChecks).toBeGreaterThanOrEqual(2);
+    expect(prepareArgs).toEqual({
+      payload: {
+        videoId: "dQw4w9WgXcQ",
+        format: "360p",
+        jobId: prepared.jobId,
+      },
+    });
+  });
+
+  test("normalizes native string rejections into actionable Error objects", async () => {
+    const adapter = createTauriMediaAdapter(async () => {
+      throw "ERROR: Requested format is not available";
+    });
+
+    try {
+      await adapter.prepare({ videoId: "dQw4w9WgXcQ", format: "360p" });
+      throw new Error("Expected native preparation to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(
+        "Requested format is not available",
+      );
+    }
+  });
+});

--- a/tests/mobile-sheet-contract.test.ts
+++ b/tests/mobile-sheet-contract.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(
+  join(import.meta.dir, "../src/components/FloatingPlayer.tsx"),
+  "utf8",
+);
+
+describe("mobile player sheet", () => {
+  test("opens roughly one-third taller by default", () => {
+    expect(source).toContain("const PEEK_VH = 60;");
+  });
+
+  test("uses the grabber to toggle sheet size without closing the sheet", () => {
+    const handler = source.slice(
+      source.indexOf("const handleGrabberClick"),
+      source.indexOf("const handleGrabberKeyDown"),
+    );
+
+    expect(handler).toContain('setSheetSnap("expanded")');
+    expect(handler).toContain('setSheetSnap("peek")');
+    expect(handler).not.toContain("closeSheet()");
+    expect(source).toContain('className="w-full h-12 shrink-0');
+  });
+});

--- a/tests/nip46-client-name.test.ts
+++ b/tests/nip46-client-name.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { nip46ClientName } from "../src/lib/nostr/nip46";
+
+describe("NIP-46 client name", () => {
+  test("appends a human-readable platform to production names", () => {
+    expect(nip46ClientName("web", true)).toBe("Wavefunc Radio · Web");
+    expect(nip46ClientName("android", true)).toBe(
+      "Wavefunc Radio · Android",
+    );
+    expect(nip46ClientName("macos", true)).toBe("Wavefunc Radio · macOS");
+    expect(nip46ClientName("windows", true)).toBe(
+      "Wavefunc Radio · Windows",
+    );
+    expect(nip46ClientName("linux", true)).toBe("Wavefunc Radio · Linux");
+    expect(nip46ClientName("ios", true)).toBe("Wavefunc Radio · iOS");
+  });
+
+  test("keeps the environment marker before the appended platform", () => {
+    expect(nip46ClientName("android", false)).toBe(
+      "Wavefunc Radio DEV · Android",
+    );
+  });
+});

--- a/tests/reload-regressions.test.tsx
+++ b/tests/reload-regressions.test.tsx
@@ -55,6 +55,25 @@ describe("reload data regressions", () => {
     expect(favoriteStations).not.toContain('message === "EOSE"');
   });
 
+  test("song lists and their tracks finish initial loads from finite requests", () => {
+    const songFavorites = readFileSync(
+      join(root, "src/lib/hooks/useSongFavorites.ts"),
+      "utf8",
+    );
+    const crate = readFileSync(join(root, "src/routes/crate.tsx"), "utf8");
+    const songResolution = crate.slice(
+      crate.indexOf("function useSongsFromList"),
+      crate.indexOf("// ─── Helpers"),
+    );
+
+    expect(songFavorites).toContain("requestEventsIntoStore(");
+    expect(songFavorites).not.toContain('message === "EOSE"');
+    expect(songResolution).toContain("requestEventsIntoStore(");
+    expect(songResolution).not.toContain(
+      "songs.length < addresses.length",
+    );
+  });
+
   test("station cards render retrieved social counts instead of tooltip-only values", () => {
     expect(renderToStaticMarkup(<SocialCount count={1} />)).toContain(">1<");
     expect(renderToStaticMarkup(<SocialCount count={1_200} />)).toContain(


### PR DESCRIPTION
## What changed

- adds reliable Android and desktop media acquisition with Blossom upload
- persists forged songs in Liked Songs before download begins
- fixes Android player insets, player-sheet behavior, Crate loading, and mobile dialogs
- restores station engagement data and updates the Applesauce-based wallet flows
- labels NIP-46 login sessions with the runtime platform
- keeps WaveFunc source MIT licensed while packaging the Android downloader GPL text and attaching its exact upstream source archive
- bumps WaveFunc to 0.1.6

## Why

Installed apps need reliable background playback and device-local media handling, while users need downloads to remain recoverable in Crate and remote signers to distinguish web, Android, macOS, and other sessions.

## Validation

- `bun test` — 43 passing
- `bun run build`
- `cargo check`
- Android 0.1.6 debug APK build
- verified packaged `assets/licenses/GPL-3.0-youtubedl-android.txt` checksum
- release workflow verifies and attaches the youtubedl-android 0.18.1 source archive and GPL text