### PR TITLE
feat: station observability and discovery signals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ VPS_PATH=/var/www/wavefunc
 
 # Server Configuration
 NODE_ENV=production
+APP_STAGE=production
 PORT=3000
 DOMAIN=your-domain.com
 TLS_EMAIL=your-email@example.com
@@ -32,6 +33,15 @@ APP_PRIVATE_KEY=0000000000000000000000000000000000000000000000000000000000000004
 METADATA_SERVER_KEY=0000000000000000000000000000000000000000000000000000000000000001
 METADATA_SERVER_PUBKEY=79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
 METADATA_CLIENT_KEY=0000000000000000000000000000000000000000000000000000000000000002
+
+# Station observer (runs inside the ContextVM service)
+# The catalog pubkey may be set without exposing the catalog private key.
+# APP_PRIVATE_KEY is only needed when opt-in redirect updates are enabled.
+CATALOG_PUBKEY=
+OBSERVER_DB_PATH=data/observer.sqlite
+HEALTH_BATCH_SIZE=40
+HEALTH_CONCURRENCY=8
+STATION_AUTO_UPDATE=false
 
 # Local Development (optional overrides)
 # Uncomment these for local development

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ contextvm/bin/
 
 # database
 legacy-db/*
+data/observer.sqlite*
 
 # cookie files
 scripts/youtube_cookies*.txt

--- a/contextvm/CONFIGURATION.md
+++ b/contextvm/CONFIGURATION.md
@@ -30,7 +30,28 @@ METADATA_CLIENT_KEY=000000000000000000000000000000000000000000000000000000000000
 
 # Relay URL (shared)
 RELAY_URL=ws://localhost:3334
+
+# App-data boundary and persistent station observer state
+APP_STAGE=development
+CATALOG_PUBKEY=<public key that signs canonical kind 31237 stations>
+OBSERVER_DB_PATH=data/observer.sqlite
+HEALTH_BATCH_SIZE=40
+HEALTH_CONCURRENCY=8
+STATION_AUTO_UPDATE=false
 ```
+
+`METADATA_SERVER_KEY` is also the observer signing key. Its matching
+`METADATA_SERVER_PUBKEY` must be bundled into the clients so they accept only
+that observer's health, current-track, and ranking snapshots.
+
+The observer reads the canonical station catalog from the app relay, stores a
+rebuildable operational index in SQLite, and checks stations over a distributed
+24-hour schedule. Set `APP_PRIVATE_KEY` and `STATION_AUTO_UPDATE=true` only when
+this process is intentionally authorized to publish repeatedly confirmed
+permanent stream redirects as catalog updates.
+
+Stage isolation is fail-closed: development app data requires a local relay,
+while production refuses local app relays.
 
 ### Generating Production Keys
 

--- a/contextvm/README.md
+++ b/contextvm/README.md
@@ -13,6 +13,9 @@ Extracts "now playing" information from Icecast/Shoutcast radio streams.
 **Input:**
 
 - `url`: Radio stream URL
+- `stationAddress` (optional): Kind `31237` address for the station
+- `sessionId` (optional): Ephemeral playback-session ID used to derive anonymous listener-minutes
+- `observedAt` (optional): Client observation time; bounded against server time
 
 **Output:**
 
@@ -69,6 +72,23 @@ bun run contextvm
 
 - `METADATA_SERVER_KEY`: Nostr private key for the server (hex format)
 - `RELAY_URL`: Relay URL (default: ws://localhost:3334)
+- `CATALOG_PUBKEY`: Public key for the canonical WaveFunc station catalog
+- `OBSERVER_DB_PATH`: Persistent observer SQLite path (default: `data/observer.sqlite`)
+- `HEALTH_BATCH_SIZE`: Maximum stations claimed by each minute tick
+- `HEALTH_CONCURRENCY`: Maximum simultaneous stream probes
+- `STATION_AUTO_UPDATE`: Opt in to confirmed permanent-redirect catalog updates
+
+## Station observer
+
+The metadata server also maintains WaveFunc's Nostr-native station observer. It
+materializes canonical kind `31237` stations into a rebuildable local index,
+probes their streams, records anonymous listening heartbeats, and publishes
+signed replaceable health (`31238`), current-track (`31239`), and ranking
+(`31240`) events. User reports remain user-signed NIP-32 kind `1985` events.
+
+The observer never imports an external station directory. Development app data
+stays on the local relay; production app data stays on the configured public app
+relay. See `CONFIGURATION.md` for the deployment variables and key separation.
 
 ## Client Usage
 

--- a/contextvm/observer/database.ts
+++ b/contextvm/observer/database.ts
@@ -1,0 +1,657 @@
+import { Database } from "bun:sqlite";
+import type { NostrEvent } from "applesauce-core/helpers/event";
+
+import {
+  STATION_KIND,
+  semanticTrackKey,
+  type ParsedStation,
+  type StationHealthStatus,
+  type StationRankingEntry,
+  type StationReportLabel,
+  type StationTrack,
+} from "../../src/lib/nostr/domain";
+import type { StreamMetadata } from "../schemas";
+
+export type ObserverStation = {
+  address: string;
+  event: NostrEvent;
+  streamUrls: string[];
+  nextCheckAt: number;
+  consecutiveFailures: number;
+};
+
+export type HealthCheckRecord = {
+  stationAddress: string;
+  checkedAt: number;
+  reachable: boolean;
+  status: StationHealthStatus;
+  score: number;
+  latencyMs?: number;
+  streamUrl?: string;
+  resolvedUrl?: string;
+  contentType?: string;
+  insecure: boolean;
+  evidence: string[];
+};
+
+type RankingRow = {
+  station_address: string;
+  value: number;
+};
+
+type TrackRow = {
+  station_address: string;
+  artist: string | null;
+  title: string | null;
+  last_seen_at: number;
+};
+
+type NowPlayingCoverageRow = RankingRow & {
+  last_seen_at: number;
+};
+
+const DAY_SECONDS = 24 * 60 * 60;
+const MAX_HEARTBEAT_CREDIT_SECONDS = 60;
+
+function scheduleOffset(address: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < address.length; index += 1) {
+    hash ^= address.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0) % DAY_SECONDS;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === "number" ? value : Number(value ?? 0);
+}
+
+export class ObserverDatabase {
+  readonly sqlite: Database;
+
+  constructor(path = process.env.OBSERVER_DB_PATH || "data/observer.sqlite") {
+    this.sqlite = new Database(path, { create: true });
+    this.sqlite.exec("PRAGMA journal_mode = WAL;");
+    this.sqlite.exec("PRAGMA foreign_keys = ON;");
+    this.migrate();
+  }
+
+  private migrate() {
+    this.sqlite.exec(`
+      CREATE TABLE IF NOT EXISTS observer_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS stations (
+        address TEXT PRIMARY KEY,
+        event_json TEXT NOT NULL,
+        streams_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        next_check_at INTEGER NOT NULL,
+        last_checked_at INTEGER,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'unknown',
+        score INTEGER NOT NULL DEFAULT 0,
+        last_health_publish_at INTEGER,
+        last_health_fingerprint TEXT,
+        redirect_candidate TEXT,
+        redirect_confirmations INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE INDEX IF NOT EXISTS stations_due_idx ON stations(next_check_at);
+
+      CREATE TABLE IF NOT EXISTS health_checks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        station_address TEXT NOT NULL,
+        checked_at INTEGER NOT NULL,
+        reachable INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        score INTEGER NOT NULL,
+        latency_ms INTEGER,
+        stream_url TEXT,
+        resolved_url TEXT,
+        content_type TEXT,
+        insecure INTEGER NOT NULL,
+        evidence_json TEXT NOT NULL,
+        FOREIGN KEY(station_address) REFERENCES stations(address) ON DELETE CASCADE
+      );
+      CREATE INDEX IF NOT EXISTS health_station_time_idx
+        ON health_checks(station_address, checked_at DESC);
+
+      CREATE TABLE IF NOT EXISTS listening_sessions (
+        session_id TEXT PRIMARY KEY,
+        station_address TEXT NOT NULL,
+        stream_url TEXT NOT NULL,
+        started_at INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL,
+        heartbeat_count INTEGER NOT NULL DEFAULT 1
+      );
+      CREATE INDEX IF NOT EXISTS listening_station_time_idx
+        ON listening_sessions(station_address, last_seen_at DESC);
+
+      CREATE TABLE IF NOT EXISTS listening_heartbeats (
+        session_id TEXT NOT NULL,
+        station_address TEXT NOT NULL,
+        observed_at INTEGER NOT NULL,
+        credited_seconds INTEGER NOT NULL,
+        PRIMARY KEY(session_id, observed_at)
+      );
+      CREATE INDEX IF NOT EXISTS listening_heartbeat_station_time_idx
+        ON listening_heartbeats(station_address, observed_at DESC);
+
+      CREATE TABLE IF NOT EXISTS track_segments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        station_address TEXT NOT NULL,
+        track_key TEXT NOT NULL,
+        artist TEXT,
+        title TEXT,
+        album TEXT,
+        mbid TEXT,
+        source TEXT,
+        started_at INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL,
+        heartbeat_count INTEGER NOT NULL DEFAULT 1
+      );
+      CREATE INDEX IF NOT EXISTS track_station_time_idx
+        ON track_segments(station_address, last_seen_at DESC);
+
+      CREATE TABLE IF NOT EXISTS published_tracks (
+        station_address TEXT PRIMARY KEY,
+        track_key TEXT NOT NULL,
+        published_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS social_events (
+        event_id TEXT PRIMARY KEY,
+        station_address TEXT NOT NULL,
+        metric TEXT NOT NULL,
+        actor_pubkey TEXT,
+        created_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS social_metric_time_idx
+        ON social_events(metric, created_at DESC);
+
+      CREATE TABLE IF NOT EXISTS station_reports (
+        event_id TEXT PRIMARY KEY,
+        station_address TEXT NOT NULL,
+        label TEXT NOT NULL,
+        reporter_pubkey TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS reports_station_time_idx
+        ON station_reports(station_address, created_at DESC);
+    `);
+  }
+
+  close() {
+    this.sqlite.close();
+  }
+
+  getMeta(key: string): string | null {
+    const row = this.sqlite
+      .query("SELECT value FROM observer_meta WHERE key = ?")
+      .get(key) as { value?: string } | null;
+    return row?.value ?? null;
+  }
+
+  setMeta(key: string, value: string) {
+    this.sqlite
+      .query(
+        `INSERT INTO observer_meta(key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(key, value);
+  }
+
+  get stationCount(): number {
+    const row = this.sqlite.query("SELECT COUNT(*) AS count FROM stations").get() as {
+      count: number;
+    };
+    return asNumber(row.count);
+  }
+
+  upsertStation(station: ParsedStation, now: number) {
+    if (!station.address || station.streams.length === 0) return;
+    const firstSchedule = now + scheduleOffset(station.address);
+    this.sqlite
+      .query(
+        `INSERT INTO stations(
+           address, event_json, streams_json, updated_at, next_check_at
+         ) VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(address) DO UPDATE SET
+           event_json = excluded.event_json,
+           streams_json = excluded.streams_json,
+           updated_at = excluded.updated_at`,
+      )
+      .run(
+        station.address,
+        JSON.stringify(station.event),
+        JSON.stringify(station.streams.map((stream) => stream.url)),
+        station.created_at,
+        firstSchedule,
+      );
+  }
+
+  dueStations(now: number, limit: number): ObserverStation[] {
+    const rows = this.sqlite
+      .query(
+        `SELECT address, event_json, streams_json, next_check_at,
+                consecutive_failures
+         FROM stations
+         WHERE next_check_at <= ?
+         ORDER BY next_check_at ASC
+         LIMIT ?`,
+      )
+      .all(now, limit) as Array<{
+      address: string;
+      event_json: string;
+      streams_json: string;
+      next_check_at: number;
+      consecutive_failures: number;
+    }>;
+
+    return rows.map((row) => ({
+      address: row.address,
+      event: JSON.parse(row.event_json) as NostrEvent,
+      streamUrls: JSON.parse(row.streams_json) as string[],
+      nextCheckAt: asNumber(row.next_check_at),
+      consecutiveFailures: asNumber(row.consecutive_failures),
+    }));
+  }
+
+  isKnownStationStream(stationAddress: string, streamUrl: string): boolean {
+    const row = this.sqlite
+      .query("SELECT streams_json FROM stations WHERE address = ?")
+      .get(stationAddress) as { streams_json: string } | null;
+    if (!row) return false;
+    try {
+      return (JSON.parse(row.streams_json) as string[]).includes(streamUrl);
+    } catch {
+      return false;
+    }
+  }
+
+  reportCounts(
+    stationAddress: string,
+    since: number,
+  ): Partial<Record<StationReportLabel, number>> {
+    const rows = this.sqlite
+      .query(
+        `SELECT label, COUNT(DISTINCT reporter_pubkey) AS count
+         FROM station_reports
+         WHERE station_address = ? AND created_at >= ?
+         GROUP BY label`,
+      )
+      .all(stationAddress, since) as Array<{ label: StationReportLabel; count: number }>;
+    return Object.fromEntries(
+      rows.map((row) => [row.label, asNumber(row.count)]),
+    );
+  }
+
+  completeHealthCheck(record: HealthCheckRecord): {
+    shouldPublish: boolean;
+    consecutiveFailures: number;
+    redirectConfirmations: number;
+  } {
+    const current = this.sqlite
+      .query(
+        `SELECT consecutive_failures, last_health_publish_at,
+                last_health_fingerprint, redirect_candidate,
+                redirect_confirmations
+         FROM stations WHERE address = ?`,
+      )
+      .get(record.stationAddress) as
+      | {
+          consecutive_failures: number;
+          last_health_publish_at: number | null;
+          last_health_fingerprint: string | null;
+          redirect_candidate: string | null;
+          redirect_confirmations: number;
+        }
+      | null;
+
+    const failures = record.reachable
+      ? 0
+      : asNumber(current?.consecutive_failures) + 1;
+    const fingerprint = `${record.status}:${record.score}:${record.insecure ? 1 : 0}`;
+    const shouldPublish =
+      current?.last_health_fingerprint !== fingerprint ||
+      !current?.last_health_publish_at ||
+      record.checkedAt - current.last_health_publish_at >= DAY_SECONDS;
+
+    const redirectCandidate =
+      record.reachable && record.resolvedUrl && record.resolvedUrl !== record.streamUrl
+        ? record.resolvedUrl
+        : null;
+    const redirectConfirmations = redirectCandidate
+      ? current?.redirect_candidate === redirectCandidate
+        ? asNumber(current.redirect_confirmations) + 1
+        : 1
+      : 0;
+
+    const transaction = this.sqlite.transaction(() => {
+      this.sqlite
+        .query(
+          `INSERT INTO health_checks(
+             station_address, checked_at, reachable, status, score, latency_ms,
+             stream_url, resolved_url, content_type, insecure, evidence_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          record.stationAddress,
+          record.checkedAt,
+          record.reachable ? 1 : 0,
+          record.status,
+          record.score,
+          record.latencyMs ?? null,
+          record.streamUrl ?? null,
+          record.resolvedUrl ?? null,
+          record.contentType ?? null,
+          record.insecure ? 1 : 0,
+          JSON.stringify(record.evidence),
+        );
+      this.sqlite
+        .query(
+          `UPDATE stations SET
+             last_checked_at = ?, next_check_at = ?, consecutive_failures = ?,
+             status = ?, score = ?,
+             last_health_publish_at = CASE WHEN ? THEN ? ELSE last_health_publish_at END,
+             last_health_fingerprint = CASE WHEN ? THEN ? ELSE last_health_fingerprint END,
+             redirect_candidate = ?, redirect_confirmations = ?
+           WHERE address = ?`,
+        )
+        .run(
+          record.checkedAt,
+          record.checkedAt + DAY_SECONDS,
+          failures,
+          record.status,
+          record.score,
+          shouldPublish ? 1 : 0,
+          record.checkedAt,
+          shouldPublish ? 1 : 0,
+          fingerprint,
+          redirectCandidate,
+          redirectConfirmations,
+          record.stationAddress,
+        );
+    });
+    transaction();
+
+    return { shouldPublish, consecutiveFailures: failures, redirectConfirmations };
+  }
+
+  recordHeartbeat(input: {
+    sessionId: string;
+    stationAddress: string;
+    streamUrl: string;
+    observedAt: number;
+    metadata: StreamMetadata;
+  }): { track: StationTrack | null; shouldPublishTrack: boolean } {
+    const observedAt = input.observedAt;
+    const previousSession = this.sqlite
+      .query(
+        `SELECT station_address, stream_url, last_seen_at
+         FROM listening_sessions WHERE session_id = ?`,
+      )
+      .get(input.sessionId) as
+      | { station_address: string; stream_url: string; last_seen_at: number }
+      | null;
+    const samePlayback =
+      previousSession?.station_address === input.stationAddress &&
+      previousSession.stream_url === input.streamUrl;
+    const creditedSeconds = samePlayback
+      ? Math.max(
+          0,
+          Math.min(
+            MAX_HEARTBEAT_CREDIT_SECONDS,
+            observedAt - asNumber(previousSession.last_seen_at),
+          ),
+        )
+      : 0;
+    const heartbeatTransaction = this.sqlite.transaction(() => {
+      this.sqlite
+        .query(
+          `INSERT INTO listening_sessions(
+             session_id, station_address, stream_url, started_at, last_seen_at
+           ) VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(session_id) DO UPDATE SET
+             station_address = excluded.station_address,
+             stream_url = excluded.stream_url,
+             started_at = CASE
+               WHEN listening_sessions.station_address != excluded.station_address
+                 OR listening_sessions.stream_url != excluded.stream_url
+               THEN excluded.started_at
+               ELSE listening_sessions.started_at
+             END,
+             last_seen_at = MAX(listening_sessions.last_seen_at, excluded.last_seen_at),
+             heartbeat_count = listening_sessions.heartbeat_count + 1`,
+        )
+        .run(
+          input.sessionId,
+          input.stationAddress,
+          input.streamUrl,
+          observedAt,
+          observedAt,
+        );
+      this.sqlite
+        .query(
+          `INSERT OR IGNORE INTO listening_heartbeats(
+             session_id, station_address, observed_at, credited_seconds
+           ) VALUES (?, ?, ?, ?)`,
+        )
+        .run(
+          input.sessionId,
+          input.stationAddress,
+          observedAt,
+          creditedSeconds,
+        );
+    });
+    heartbeatTransaction();
+
+    const track: StationTrack = {
+      stationAddress: input.stationAddress,
+      observedAt,
+      artist: input.metadata.artist || input.metadata.enriched?.artist,
+      song:
+        input.metadata.song ||
+        input.metadata.enriched?.title ||
+        input.metadata.title,
+      title: input.metadata.title,
+      album: input.metadata.enriched?.album,
+      mbid: input.metadata.enriched?.mbid,
+      source: input.metadata.source,
+    };
+    const trackKey = semanticTrackKey(track);
+    if (!trackKey) return { track: null, shouldPublishTrack: false };
+
+    const current = this.sqlite
+      .query(
+        `SELECT id, track_key FROM track_segments
+         WHERE station_address = ?
+         ORDER BY last_seen_at DESC LIMIT 1`,
+      )
+      .get(input.stationAddress) as { id: number; track_key: string } | null;
+    if (current?.track_key === trackKey) {
+      this.sqlite
+        .query(
+          `UPDATE track_segments SET last_seen_at = ?, heartbeat_count = heartbeat_count + 1
+           WHERE id = ?`,
+        )
+        .run(observedAt, current.id);
+    } else {
+      this.sqlite
+        .query(
+          `INSERT INTO track_segments(
+             station_address, track_key, artist, title, album, mbid, source,
+             started_at, last_seen_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          input.stationAddress,
+          trackKey,
+          track.artist ?? null,
+          track.song ?? track.title ?? null,
+          track.album ?? null,
+          track.mbid ?? null,
+          track.source ?? null,
+          observedAt,
+          observedAt,
+        );
+    }
+
+    const published = this.sqlite
+      .query(
+        "SELECT track_key, published_at FROM published_tracks WHERE station_address = ?",
+      )
+      .get(input.stationAddress) as { track_key: string; published_at: number } | null;
+    const shouldPublishTrack =
+      published?.track_key !== trackKey ||
+      !published?.published_at ||
+      observedAt - published.published_at >= 2 * 60;
+    if (shouldPublishTrack) {
+      this.sqlite
+        .query(
+          `INSERT INTO published_tracks(station_address, track_key, published_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT(station_address) DO UPDATE SET
+             track_key = excluded.track_key,
+             published_at = excluded.published_at`,
+        )
+        .run(input.stationAddress, trackKey, observedAt);
+    }
+
+    return { track, shouldPublishTrack };
+  }
+
+  ingestSocialEvent(event: NostrEvent): boolean {
+    const stationAddress = event.tags.find(
+      ([name, value]) => name === "a" && value?.startsWith(`${STATION_KIND}:`),
+    )?.[1];
+    if (!stationAddress) return false;
+    const metric = event.kind === 7 ? "like" : event.kind === 9735 || event.kind === 9321 ? "zap" : null;
+    if (!metric) return false;
+    const result = this.sqlite
+      .query(
+        `INSERT OR IGNORE INTO social_events(
+           event_id, station_address, metric, actor_pubkey, created_at
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(event.id, stationAddress, metric, event.pubkey, event.created_at);
+    return result.changes > 0;
+  }
+
+  ingestReport(event: NostrEvent): boolean {
+    if (event.kind !== 1985) return false;
+    const stationAddress = event.tags.find(
+      ([name, value]) => name === "a" && value?.startsWith(`${STATION_KIND}:`),
+    )?.[1];
+    const label = event.tags.find(
+      ([name, , namespace]) =>
+        name === "l" && namespace === "wavefunc.station-status",
+    )?.[1] as StationReportLabel | undefined;
+    if (!stationAddress || !label) return false;
+    const result = this.sqlite
+      .query(
+        `INSERT OR IGNORE INTO station_reports(
+           event_id, station_address, label, reporter_pubkey, created_at
+         ) VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(event.id, stationAddress, label, event.pubkey, event.created_at);
+    return result.changes > 0;
+  }
+
+  ranking(metric: "like" | "zap", since: number, limit: number): StationRankingEntry[] {
+    const distinct = metric === "like" ? "actor_pubkey" : "event_id";
+    const rows = this.sqlite
+      .query(
+        `SELECT station_address, COUNT(DISTINCT ${distinct}) AS value
+         FROM social_events
+         WHERE metric = ? AND created_at >= ?
+         GROUP BY station_address
+         ORDER BY value DESC
+         LIMIT ?`,
+      )
+      .all(metric, since, limit) as RankingRow[];
+    return rows.map((row) => ({
+      stationAddress: row.station_address,
+      value: asNumber(row.value),
+    }));
+  }
+
+  bestSignal(since: number, limit: number): StationRankingEntry[] {
+    const rows = this.sqlite
+      .query(
+        `SELECT address AS station_address, score AS value
+         FROM stations
+         WHERE last_checked_at >= ? AND status IN ('up', 'degraded')
+         ORDER BY score DESC, last_checked_at DESC
+         LIMIT ?`,
+      )
+      .all(since, limit) as RankingRow[];
+    return rows.map((row) => ({
+      stationAddress: row.station_address,
+      value: asNumber(row.value),
+      label: "SIGNAL_SCORE",
+    }));
+  }
+
+  mostListened(since: number, now: number, limit: number): StationRankingEntry[] {
+    const rows = this.sqlite
+      .query(
+        `SELECT station_address,
+                SUM(credited_seconds) / 60.0 AS value
+         FROM listening_heartbeats
+         WHERE observed_at >= ? AND observed_at <= ?
+         GROUP BY station_address
+         HAVING value > 0
+         ORDER BY value DESC
+         LIMIT ?`,
+      )
+      .all(since, now, limit) as RankingRow[];
+    return rows.map((row) => ({
+      stationAddress: row.station_address,
+      value: Math.round(asNumber(row.value) * 10) / 10,
+      label: "LISTENER_MIN",
+    }));
+  }
+
+  hasNowPlaying(since: number, limit: number): StationRankingEntry[] {
+    const rows = this.sqlite
+      .query(
+        `SELECT station_address, COUNT(*) AS value,
+                MAX(last_seen_at) AS last_seen_at
+         FROM track_segments
+         WHERE last_seen_at >= ?
+         GROUP BY station_address
+         ORDER BY last_seen_at DESC, value DESC
+         LIMIT ?`,
+      )
+      .all(since, limit) as NowPlayingCoverageRow[];
+    return rows.map((row) => ({
+      stationAddress: row.station_address,
+      value: asNumber(row.value),
+      label: "TRACKS_OBSERVED",
+      observedAt: asNumber(row.last_seen_at),
+    }));
+  }
+
+  onAirNow(since: number, limit: number): StationRankingEntry[] {
+    const rows = this.sqlite
+      .query(
+        `SELECT station_address, artist, title, MAX(last_seen_at) AS last_seen_at
+         FROM track_segments
+         WHERE last_seen_at >= ?
+         GROUP BY station_address
+         ORDER BY last_seen_at DESC
+         LIMIT ?`,
+      )
+      .all(since, limit) as TrackRow[];
+    return rows.map((row) => ({
+      stationAddress: row.station_address,
+      value: 1,
+      artist: row.artist ?? undefined,
+      title: row.title ?? undefined,
+      observedAt: asNumber(row.last_seen_at),
+    }));
+  }
+}

--- a/contextvm/observer/probe.ts
+++ b/contextvm/observer/probe.ts
@@ -1,0 +1,84 @@
+export type StreamProbeResult = {
+  reachable: boolean;
+  latencyMs: number;
+  streamUrl: string;
+  resolvedUrl?: string;
+  contentType?: string;
+  statusCode?: number;
+  insecure: boolean;
+  permanentRedirect: boolean;
+  error?: string;
+};
+
+const REDIRECT_CODES = new Set([301, 302, 303, 307, 308]);
+const PERMANENT_REDIRECT_CODES = new Set([301, 308]);
+
+export async function probeStreamHealth(
+  streamUrl: string,
+  timeoutMs = 12_000,
+): Promise<StreamProbeResult> {
+  const startedAt = performance.now();
+  let currentUrl = streamUrl;
+  let permanentRedirect = false;
+
+  try {
+    for (let redirects = 0; redirects <= 5; redirects += 1) {
+      const response = await fetch(currentUrl, {
+        method: "GET",
+        redirect: "manual",
+        headers: {
+          Accept: "audio/*,application/vnd.apple.mpegurl,application/x-mpegURL,*/*;q=0.1",
+          Range: "bytes=0-1023",
+          "Icy-MetaData": "1",
+          "User-Agent": "WaveFunc-Observer/1.0",
+        },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+      if (REDIRECT_CODES.has(response.status)) {
+        const location = response.headers.get("location");
+        if (!location) throw new Error(`Redirect ${response.status} without Location`);
+        permanentRedirect ||= PERMANENT_REDIRECT_CODES.has(response.status);
+        currentUrl = new URL(location, currentUrl).toString();
+        continue;
+      }
+
+      const reachable = response.ok || response.status === 206;
+      if (reachable && response.body) {
+        const reader = response.body.getReader();
+        await reader.read();
+        await reader.cancel().catch(() => undefined);
+      }
+
+      return {
+        reachable,
+        latencyMs: Math.max(0, Math.round(performance.now() - startedAt)),
+        streamUrl,
+        resolvedUrl: currentUrl,
+        contentType: response.headers.get("content-type") ?? undefined,
+        statusCode: response.status,
+        insecure: new URL(streamUrl).protocol === "http:",
+        permanentRedirect,
+        ...(!reachable ? { error: `HTTP ${response.status}` } : {}),
+      };
+    }
+
+    throw new Error("Too many redirects");
+  } catch (error) {
+    return {
+      reachable: false,
+      latencyMs: Math.max(0, Math.round(performance.now() - startedAt)),
+      streamUrl,
+      resolvedUrl: currentUrl,
+      insecure: (() => {
+        try {
+          return new URL(streamUrl).protocol === "http:";
+        } catch {
+          return false;
+        }
+      })(),
+      permanentRedirect,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/contextvm/observer/service.ts
+++ b/contextvm/observer/service.ts
@@ -1,0 +1,476 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+import type { NostrEvent } from "applesauce-core/helpers/event";
+import type { Filter } from "applesauce-core/helpers/filter";
+import { RelayPool } from "applesauce-relay";
+import { PrivateKeySigner } from "applesauce-signers";
+import { getPublicKey } from "nostr-tools/pure";
+import { hexToBytes } from "nostr-tools/utils";
+import type { Subscription } from "rxjs";
+
+import {
+  STATION_KIND,
+  buildStationHealthTemplate,
+  buildStationRankingTemplate,
+  buildStationTemplate,
+  buildStationTrackTemplate,
+  calculateStationHealthScore,
+  parseStationEvent,
+  type StationRankingMetric,
+  type StationRankingSnapshot,
+} from "../../src/lib/nostr/domain";
+import type { EventTemplate } from "../../src/lib/nostr/types";
+import { createRelayPolicy } from "../../src/config/relayPolicy";
+import type { StreamMetadata } from "../schemas";
+import { ObserverDatabase, type ObserverStation } from "./database";
+import { probeStreamHealth, type StreamProbeResult } from "./probe";
+
+const DAY_SECONDS = 24 * 60 * 60;
+const WEEK_SECONDS = 7 * DAY_SECONDS;
+
+export type StationObserverOptions = {
+  appRelay: string;
+  observerPrivateKey: string;
+  catalogPrivateKey?: string;
+  catalogPubkey?: string;
+  databasePath?: string;
+  batchSize?: number;
+  concurrency?: number;
+  autoUpdateCatalog?: boolean;
+  now?: () => number;
+};
+
+function unixNow() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function ensureDatabaseDirectory(path: string) {
+  if (path === ":memory:") return;
+  const directory = dirname(path);
+  if (directory && directory !== ".") mkdirSync(directory, { recursive: true });
+}
+
+function runBounded<T>(
+  values: T[],
+  concurrency: number,
+  task: (value: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(concurrency, values.length)) },
+    async () => {
+      while (cursor < values.length) {
+        const value = values[cursor];
+        cursor += 1;
+        if (value !== undefined) await task(value);
+      }
+    },
+  );
+  return Promise.all(workers).then(() => undefined);
+}
+
+export class StationObserver {
+  readonly database: ObserverDatabase;
+  readonly observerPubkey: Promise<string>;
+
+  private readonly pool = new RelayPool();
+  private readonly observerSigner: PrivateKeySigner;
+  private readonly catalogSigner?: PrivateKeySigner;
+  private readonly catalogPubkey?: string;
+  private readonly now: () => number;
+  private readonly subscriptions: Subscription[] = [];
+  private readonly timers: ReturnType<typeof setInterval>[] = [];
+  private healthBatchRunning = false;
+  private rankingPublishRunning = false;
+
+  constructor(private readonly options: StationObserverOptions) {
+    const databasePath = options.databasePath ?? "data/observer.sqlite";
+    ensureDatabaseDirectory(databasePath);
+    this.database = new ObserverDatabase(databasePath);
+    this.observerSigner = PrivateKeySigner.fromKey(options.observerPrivateKey);
+    this.observerPubkey = this.observerSigner.getPublicKey();
+    this.catalogSigner = options.catalogPrivateKey
+      ? PrivateKeySigner.fromKey(options.catalogPrivateKey)
+      : undefined;
+    this.catalogPubkey =
+      options.catalogPubkey ??
+      (options.catalogPrivateKey
+        ? getPublicKey(hexToBytes(options.catalogPrivateKey))
+        : undefined);
+    this.now = options.now ?? unixNow;
+    this.pool.relay(options.appRelay);
+  }
+
+  async start() {
+    console.log(
+      `📊 Station observer using ${this.options.appRelay} (${this.database.stationCount} cached stations)`,
+    );
+    if (!this.catalogPubkey) {
+      console.warn(
+        "⚠️ Station observer catalog sync disabled: set APP_PRIVATE_KEY or CATALOG_PUBKEY",
+      );
+    } else {
+      await this.syncCatalog();
+      this.subscribeCatalog();
+    }
+    await this.syncEvidence();
+    this.subscribeEvidence();
+    await this.publishRankings();
+    this.runBackground("health batch", () => this.runHealthBatch());
+
+    this.timers.push(
+      setInterval(
+        () => this.runBackground("health batch", () => this.runHealthBatch()),
+        60_000,
+      ),
+      setInterval(
+        () => this.runBackground("evidence sync", () => this.syncEvidence()),
+        15 * 60_000,
+      ),
+      setInterval(
+        () => this.runBackground("ranking publish", () => this.publishRankings()),
+        60 * 60_000,
+      ),
+    );
+  }
+
+  private runBackground(label: string, task: () => Promise<void>) {
+    void task().catch((error) => {
+      console.warn(`Station observer ${label} failed:`, error);
+    });
+  }
+
+  stop() {
+    for (const timer of this.timers) clearInterval(timer);
+    this.timers.length = 0;
+    for (const subscription of this.subscriptions) subscription.unsubscribe();
+    this.subscriptions.length = 0;
+    this.pool.close();
+    this.database.close();
+  }
+
+  private async publish(template: EventTemplate, signer = this.observerSigner) {
+    const event = await signer.signEvent({
+      ...template,
+      created_at: template.created_at ?? this.now(),
+    });
+    const responses = await this.pool.publish([this.options.appRelay], event);
+    if (!responses.some((response) => response.ok)) {
+      throw new Error(
+        responses
+          .map((response) => `${response.from}: ${response.message ?? "rejected"}`)
+          .join("; ") || "Observer event was rejected",
+      );
+    }
+    return event;
+  }
+
+  private request(filters: Filter[], onEvent: (event: NostrEvent) => void) {
+    return new Promise<void>((resolve, reject) => {
+      this.pool.request([this.options.appRelay], filters).subscribe({
+        next: onEvent,
+        complete: resolve,
+        error: reject,
+      });
+    });
+  }
+
+  private ingestCatalogEvent = (event: NostrEvent) => {
+    if (event.kind !== STATION_KIND || event.pubkey !== this.catalogPubkey) return;
+    const station = parseStationEvent(event, [this.options.appRelay]);
+    this.database.upsertStation(station, this.now());
+  };
+
+  private async syncCatalog() {
+    if (!this.catalogPubkey) return;
+    const lastSync = Number(this.database.getMeta("catalog_last_sync") ?? 0);
+    const filters: Filter[] = [
+      {
+        kinds: [STATION_KIND],
+        authors: [this.catalogPubkey],
+        ...(this.database.stationCount > 0 && lastSync > 0
+          ? { since: Math.max(0, lastSync - 60) }
+          : {}),
+      },
+    ];
+    await this.request(filters, this.ingestCatalogEvent);
+    this.database.setMeta("catalog_last_sync", String(this.now()));
+    console.log(`📻 Observer registry contains ${this.database.stationCount} stations`);
+  }
+
+  private subscribeCatalog() {
+    if (!this.catalogPubkey) return;
+    this.subscriptions.push(
+      this.pool
+        .subscription([this.options.appRelay], [
+          { kinds: [STATION_KIND], authors: [this.catalogPubkey] },
+        ])
+        .subscribe({ next: this.ingestCatalogEvent }),
+    );
+  }
+
+  private ingestEvidenceEvent = (event: NostrEvent) => {
+    this.database.ingestSocialEvent(event);
+    this.database.ingestReport(event);
+  };
+
+  private async syncEvidence() {
+    const lastSync = Number(this.database.getMeta("evidence_last_sync") ?? 0);
+    await this.request(
+      [
+        {
+          kinds: [7, 9735, 9321, 1985],
+          ...(lastSync > 0 ? { since: Math.max(0, lastSync - 60) } : {}),
+        },
+      ],
+      this.ingestEvidenceEvent,
+    );
+    this.database.setMeta("evidence_last_sync", String(this.now()));
+  }
+
+  private subscribeEvidence() {
+    this.subscriptions.push(
+      this.pool
+        .subscription([this.options.appRelay], [
+          { kinds: [7, 9735, 9321, 1985] },
+        ])
+        .subscribe({ next: this.ingestEvidenceEvent }),
+    );
+  }
+
+  private async probeStation(station: ObserverStation) {
+    const checkedAt = this.now();
+    let result: StreamProbeResult | null = null;
+    for (const streamUrl of station.streamUrls) {
+      result = await probeStreamHealth(streamUrl);
+      if (result.reachable) break;
+    }
+    if (!result) return;
+
+    const failures = result.reachable ? 0 : station.consecutiveFailures + 1;
+    const reports = this.database.reportCounts(
+      station.address,
+      checkedAt - WEEK_SECONDS,
+    );
+    const calculated = calculateStationHealthScore({
+      reachable: result.reachable,
+      consecutiveFailures: failures,
+      insecure: result.insecure,
+      reports,
+    });
+    const completion = this.database.completeHealthCheck({
+      stationAddress: station.address,
+      checkedAt,
+      reachable: result.reachable,
+      status: calculated.status,
+      score: calculated.score,
+      latencyMs: result.latencyMs,
+      streamUrl: result.streamUrl,
+      resolvedUrl: result.resolvedUrl,
+      contentType: result.contentType,
+      insecure: result.insecure,
+      evidence: [
+        ...calculated.evidence,
+        ...(result.error ? [result.error] : []),
+      ],
+    });
+
+    if (completion.shouldPublish) {
+      await this.publish(
+        buildStationHealthTemplate({
+          stationAddress: station.address,
+          checkedAt,
+          status: calculated.status,
+          score: calculated.score,
+          latencyMs: result.latencyMs,
+          consecutiveFailures: completion.consecutiveFailures,
+          streamUrl: result.streamUrl,
+          resolvedUrl: result.resolvedUrl,
+          contentType: result.contentType,
+          insecure: result.insecure,
+          evidence: calculated.evidence,
+        }),
+      );
+    }
+
+    if (
+      result.reachable &&
+      result.permanentRedirect &&
+      completion.redirectConfirmations >= 3
+    ) {
+      await this.updatePermanentRedirect(station, result);
+    }
+  }
+
+  async runHealthBatch() {
+    if (this.healthBatchRunning) return;
+    this.healthBatchRunning = true;
+    try {
+      const stations = this.database.dueStations(
+        this.now(),
+        this.options.batchSize ?? 40,
+      );
+      await runBounded(stations, this.options.concurrency ?? 8, async (station) => {
+        try {
+          await this.probeStation(station);
+        } catch (error) {
+          console.warn(`Health check failed for ${station.address}:`, error);
+        }
+      });
+    } finally {
+      this.healthBatchRunning = false;
+    }
+  }
+
+  private async updatePermanentRedirect(
+    stationRecord: ObserverStation,
+    result: StreamProbeResult,
+  ) {
+    if (
+      !this.options.autoUpdateCatalog ||
+      !this.catalogSigner ||
+      !result.resolvedUrl ||
+      result.resolvedUrl === result.streamUrl
+    ) {
+      return;
+    }
+    const station = parseStationEvent(stationRecord.event, [this.options.appRelay]);
+    if (!station.stationId || !station.name || station.streams.length === 0) return;
+    const streams = station.streams.map((stream) =>
+      stream.url === result.streamUrl
+        ? { ...stream, url: result.resolvedUrl! }
+        : stream,
+    );
+    await this.publish(
+      buildStationTemplate({
+        stationId: station.stationId,
+        name: station.name,
+        description: station.description ?? station.name,
+        thumbnail: station.thumbnail,
+        website: station.website,
+        location: station.location,
+        countryCode: station.countryCode,
+        genres: station.genres,
+        languages: station.languages,
+        streams,
+        streamingServerUrl: station.streamingServerUrl,
+      }),
+      this.catalogSigner,
+    );
+    console.log(`🔁 Updated permanent redirect for ${station.address}`);
+  }
+
+  async observeMetadata(input: {
+    stationAddress?: string;
+    sessionId?: string;
+    streamUrl: string;
+    observedAt?: number;
+    metadata: StreamMetadata;
+  }) {
+    if (!input.stationAddress || !input.sessionId) return;
+    if (!this.database.isKnownStationStream(input.stationAddress, input.streamUrl)) {
+      return;
+    }
+    const serverNow = this.now();
+    const observedAt =
+      input.observedAt !== undefined && Math.abs(input.observedAt - serverNow) <= 2 * 60
+        ? input.observedAt
+        : serverNow;
+    const result = this.database.recordHeartbeat({
+      sessionId: input.sessionId,
+      stationAddress: input.stationAddress,
+      streamUrl: input.streamUrl,
+      observedAt,
+      metadata: input.metadata,
+    });
+    if (result.track && result.shouldPublishTrack) {
+      await this.publish(buildStationTrackTemplate(result.track));
+    }
+  }
+
+  async publishRankings() {
+    if (this.rankingPublishRunning) return;
+    this.rankingPublishRunning = true;
+    try {
+      const now = this.now();
+      const snapshots: Array<{
+        metric: StationRankingMetric;
+        window: string;
+        entries: StationRankingSnapshot["entries"];
+      }> = [
+        {
+          metric: "best-signal",
+          window: "latest",
+          entries: this.database.bestSignal(now - 36 * 60 * 60, 12),
+        },
+        {
+          metric: "has-now-playing",
+          window: "24h",
+          entries: this.database.hasNowPlaying(now - DAY_SECONDS, 12),
+        },
+        {
+          metric: "most-listened",
+          window: "24h",
+          entries: this.database.mostListened(now - DAY_SECONDS, now, 12),
+        },
+        {
+          metric: "most-liked",
+          window: "7d",
+          entries: this.database.ranking("like", now - WEEK_SECONDS, 12),
+        },
+        {
+          metric: "most-zapped",
+          window: "7d",
+          entries: this.database.ranking("zap", now - WEEK_SECONDS, 12),
+        },
+        {
+          metric: "on-air-now",
+          window: "2m",
+          entries: this.database.onAirNow(now - 2 * 60, 12),
+        },
+      ];
+
+      for (const snapshot of snapshots) {
+        await this.publish(
+          buildStationRankingTemplate({
+            ...snapshot,
+            generatedAt: now,
+          }),
+        );
+      }
+    } finally {
+      this.rankingPublishRunning = false;
+    }
+  }
+}
+
+export function createStationObserverFromEnvironment(input: {
+  appRelay: string;
+  observerPrivateKey: string;
+}) {
+  const stage =
+    process.env.APP_STAGE === "production" ||
+    (process.env.APP_STAGE !== "development" && process.env.NODE_ENV === "production")
+      ? "production"
+      : "development";
+  // Reuse the client policy's fail-closed local/public boundary. The observer
+  // must never turn a dev relay into a bridge to production app data.
+  createRelayPolicy({ stage, appRelay: input.appRelay });
+  const configuredBatchSize = Number(process.env.HEALTH_BATCH_SIZE || 40);
+  const configuredConcurrency = Number(process.env.HEALTH_CONCURRENCY || 8);
+  return new StationObserver({
+    appRelay: input.appRelay,
+    observerPrivateKey: input.observerPrivateKey,
+    catalogPrivateKey: process.env.APP_PRIVATE_KEY,
+    catalogPubkey: process.env.CATALOG_PUBKEY,
+    databasePath: process.env.OBSERVER_DB_PATH || "data/observer.sqlite",
+    batchSize: Number.isFinite(configuredBatchSize)
+      ? Math.max(1, Math.min(500, Math.trunc(configuredBatchSize)))
+      : 40,
+    concurrency: Number.isFinite(configuredConcurrency)
+      ? Math.max(1, Math.min(32, Math.trunc(configuredConcurrency)))
+      : 8,
+    autoUpdateCatalog: process.env.STATION_AUTO_UPDATE === "true",
+  });
+}

--- a/contextvm/schemas.ts
+++ b/contextvm/schemas.ts
@@ -139,6 +139,23 @@ export type MusicBrainzResult =
 
 export const extractStreamMetadataInputSchema = {
   url: z.string().describe("The URL of the Icecast/Shoutcast stream"),
+  stationAddress: z
+    .string()
+    .startsWith("31237:")
+    .optional()
+    .describe("Optional kind 31237 station address for anonymous listening telemetry"),
+  sessionId: z
+    .string()
+    .min(8)
+    .max(128)
+    .optional()
+    .describe("Ephemeral playback session ID; never an account pubkey"),
+  observedAt: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("Client observation time as Unix seconds"),
 };
 
 export const extractStreamMetadataOutputSchema = {
@@ -147,6 +164,9 @@ export const extractStreamMetadataOutputSchema = {
 
 export type ExtractStreamMetadataInput = {
   url: string;
+  stationAddress?: string;
+  sessionId?: string;
+  observedAt?: number;
 };
 
 export type ExtractStreamMetadataOutput = {

--- a/contextvm/server.ts
+++ b/contextvm/server.ts
@@ -12,6 +12,7 @@ import {
   searchRecordingsCombined,
 } from "./tools/musicbrainz.ts";
 import { searchYouTube, prepareDownload, uploadToBlossomWithSignedEvent } from "./tools/ytdlp.ts";
+import { createStationObserverFromEnvironment } from "./observer/service.ts";
 import {
   extractStreamMetadataInputSchema,
   extractStreamMetadataOutputSchema,
@@ -44,6 +45,11 @@ const RELAYS = [
   "wss://relay2.contextvm.org/",
 ];
 
+const stationObserver = createStationObserverFromEnvironment({
+  appRelay: RELAYS[0]!,
+  observerPrivateKey: SERVER_PRIVATE_KEY,
+});
+
 async function main() {
   console.log("🎵 Starting ContextVM Metadata Server...\n");
 
@@ -71,10 +77,24 @@ async function main() {
       inputSchema: extractStreamMetadataInputSchema,
       outputSchema: extractStreamMetadataOutputSchema,
     },
-    async ({ url }) => {
+    async ({ url, stationAddress, sessionId, observedAt }) => {
       try {
         console.log(`🎧 Extracting metadata from: ${url}`);
         const metadata = await extractIcecastMetadata(url);
+
+        try {
+          await stationObserver.observeMetadata({
+            stationAddress,
+            sessionId,
+            observedAt,
+            streamUrl: url,
+            metadata,
+          });
+        } catch (observerError) {
+          // Listening telemetry is deliberately non-critical. Metadata remains
+          // useful even if the observer relay or local database is unavailable.
+          console.warn("Station observation failed:", observerError);
+        }
 
         console.log(`✅ Extracted metadata:`, metadata);
 
@@ -480,6 +500,10 @@ async function main() {
 
   // Log when requests are received
   console.log("👂 Listening for tool requests...\n");
+
+  void stationObserver.start().catch((error) => {
+    console.error("❌ Station observer failed to start:", error);
+  });
 }
 
 // Start the server

--- a/docs/STATION_OBSERVABILITY_PLAN.md
+++ b/docs/STATION_OBSERVABILITY_PLAN.md
@@ -1,0 +1,122 @@
+# Station observability and discovery plan
+
+**Status:** Implemented
+**Branch:** `feature/health`
+**Scope:** Nostr-native station monitoring and discovery without Radio Browser imports
+
+## Objective
+
+Make WaveFunc's existing, WaveFunc-signed kind `31237` station events the canonical catalog, continuously measure station quality and listening activity, publish portable signed summaries to Nostr, and turn those summaries into useful discovery surfaces in the app.
+
+The operational database is a rebuildable index and history store. It is not the catalog and must never become the only source of a public fact.
+
+## Architecture and trust boundaries
+
+| Responsibility | Source of truth | Signing identity |
+|---|---|---|
+| Station identity and editable station data | Addressable kind `31237` events | WaveFunc catalog key (`APP_PRIVATE_KEY`) |
+| Stream health and current track | Addressable observation events | Observer/ContextVM key (`METADATA_SERVER_KEY`) |
+| Rankings and compact discovery lists | Addressable aggregate events | Observer/aggregator key |
+| Human reports and confirmations | NIP-32 kind `1985` labels targeting a station `a` address | Reporting user |
+| Scheduling, probe history, listening sessions, and track history | Local SQLite database | Not public by itself |
+
+Production observers read the WaveFunc app relay for the catalog and reports. Development observers use only the local app relay for app data. Client identity, wallet, and zap reads keep their existing role-specific public-relay policy; no development fixtures are published to public relays.
+
+## Public event contracts
+
+- `31238` — station health summary. Stable `d` is the station address; tags include `a`, status, score, checked time, and optional expiry.
+- `31239` — current track observation. Stable `d` is the station address; tags include `a`, artist/title when known, and a short NIP-40 expiration.
+- `31240` — ranking snapshot. Stable `d` identifies metric/window, such as `most-liked:7d`, `most-zapped:7d`, or `most-listened:24h`.
+- `1985` — user report/confirmation labels. Supported labels: `down`, `up`, `ads`, `adfree`, `http-insecure`, `metadata-wrong`, and `duplicate`.
+
+All parsers reject malformed content and preserve the referenced kind `31237` address. Current-track events are published only when the semantic track changes or the prior observation needs a TTL refresh; the 15-second client heartbeat is not mirrored into Nostr.
+
+## Data collection
+
+1. On first start, materialize the complete WaveFunc-signed station catalog from Nostr into SQLite. Later starts request only catalog updates since the last sync and maintain a live subscription.
+2. Distribute `next_check_at` across a 24-hour window. A minute loop claims a bounded batch with limited concurrency so every registered station is checked at least daily without a thundering herd.
+3. Record status, latency, resolved URL, content type, and insecure HTTP state. A permanent redirect is only a catalog-update candidate; catalog mutation requires repeated confirmation and an explicitly enabled catalog updater.
+4. Treat ContextVM metadata calls as anonymous session heartbeats. A session uses an ephemeral random ID, station address, and timestamps—never an account pubkey. Derive listener-minutes and active listeners from sessions rather than counting requests as listens.
+5. Store track segments in SQLite. Publish the current track to Nostr on change/refresh and derive aggregate track rankings from segments instead of publishing every poll.
+6. Ingest WaveFunc-targeted reactions, zap receipts, and NIP-32 reports from the app relay incrementally. Deduplicate likes per author and all events by event ID.
+
+## Quality score
+
+The first score is intentionally explainable:
+
+- A successful scheduled probe establishes an `up` baseline.
+- Failed probes reduce the score with consecutive-failure pressure; repeated failures produce `down`.
+- Plain HTTP is surfaced as `http-insecure` and carries a modest penalty, but remains playable by native apps.
+- Recent unique community confirmations adjust the score within a capped range. They cannot overpower the automated probe or directly rewrite the catalog.
+- Ads/ad-free and metadata-quality labels remain visible evidence and may affect ordering, but do not make an otherwise unreachable stream healthy.
+
+## UI contract
+
+The landing page keeps `FEATURED_COLLECTIONS` first and adds a compact `SIGNAL_CHARTS` block before genre rows:
+
+- `BEST_SIGNAL` — latest verified station-health score.
+- `HAS_NOW_PLAYING` — stations with successful track metadata during the last 24 hours.
+- `MOST_LISTENED` — listener-minutes over 24 hours.
+- `MOST_LIKED` — unique reaction authors over 7 days.
+- `MOST_ZAPPED` — unique zap receipts over 7 days.
+- `ON_AIR_NOW` — fresh current-track observations, when available.
+- `RECENT_DOWNLOADS` — the latest signed song records that point to a user-persisted Blossom file.
+
+Desktop uses a two-column chart grid. Mobile uses one horizontal, snap-scrolling rail per chart so the feature does not turn the landing page into a long stack. Each item remains a real station action surface: rank, artwork/name, metric, and play button.
+
+Station cards display the aggregate quality score directly (`QUALITY_0`–`QUALITY_100`) together with its state (`UP`, `DEGRADED`, `DOWN`, or `INSECURE`). The persistent player uses the compact `Q_92` form and shows `Q_—` while a selected station awaits its first check. Missing evidence is never presented as a bad score. The station detail view exposes a report/confirm control for authenticated users.
+
+Recent downloads sit in the same two-column grid as observer rankings and reuse signed kind `31337` song records containing both a Blossom file URL and their original YouTube identifier. This lets users replay or save a recently persisted file without making local browser history a source of truth.
+
+Favorites list cards have a fixed internal station viewport with touch momentum, overscroll containment, and a visible slim scrollbar. The page itself should not grow indefinitely with a long list.
+
+## Delivery tasks
+
+### 1. Event and scoring contracts
+
+- Add builders/parsers for kinds `31238`–`31240` and NIP-32 station labels.
+- Add deterministic health scoring and semantic track identity helpers.
+- Verify malformed, expired, and incorrectly targeted observations are rejected.
+
+### 2. Observer service
+
+- Add the SQLite schema, incremental catalog/report/social synchronization, daily scheduler, bounded stream probe, listening heartbeat recording, track segments, and aggregate snapshot publication.
+- Extend `extract_stream_metadata` with optional station/session context while keeping old clients compatible.
+- Keep observer and catalog keys separate; make automatic catalog redirect updates opt-in and repetition-gated.
+
+### 3. Client discovery data
+
+- Add cached Applesauce timeline hooks for signed health, current-track, and ranking events.
+- Resolve ranking addresses through the existing parameterized station loader.
+- Ensure no new per-card relay subscriptions are introduced.
+
+### 4. Landing and station UI
+
+- Add responsive signal charts for best signal, now-playing capability, most listened, liked, zapped, and currently playing.
+- Add station health presentation and authenticated NIP-32 reporting.
+- Make favorites station viewports reliably scrollable on web, Android, and desktop.
+
+### 5. Verification and rollout
+
+- Unit-test event contracts, score calculation, database aggregation, stage isolation, and UI source contracts.
+- Run the full Bun test suite and production build.
+- Visually check 360–541 px mobile widths and desktop layout.
+- Deploy with a persistent `OBSERVER_DB_PATH`, the observer key, and the existing catalog key. Let the observer build history before using quality as a hard filter.
+
+## Acceptance criteria
+
+- The scheduler can rebuild its registry from kind `31237` events signed by the configured catalog pubkey and does not import Radio Browser data.
+- Every stored station gets a due time within 24 hours, and checks are bounded by configured batch/concurrency limits.
+- Metadata polling sends an anonymous session heartbeat; repeated 15-second requests do not inflate listen starts.
+- A changed current track produces one replaceable expiring event; an unchanged track does not publish on every heartbeat.
+- Landing charts render from signed kind `31240` snapshots and disappear cleanly when no snapshot exists—no permanent skeletons.
+- Most-liked counts unique reacting pubkeys. Most-zapped counts unique receipt events. Most-listened uses listener-minutes.
+- Development app data stays local; production refuses localhost app relays.
+- Favorites list internals scroll independently with touch momentum.
+- Tests and production build pass.
+
+## Deliberate rollout constraints
+
+- Quality starts as advisory. Do not hide stations solely because the observer has little history.
+- Automatic permanent-redirect catalog updates require `STATION_AUTO_UPDATE=true`, the catalog key, and repeated confirmation.
+- New station discovery is community/WaveFunc submission work, not an external directory import. This phase establishes the health and evidence pipeline those submissions will use.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-react-template",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/deploy-remote.sh
+++ b/scripts/deploy-remote.sh
@@ -71,9 +71,9 @@ CGO_ENABLED=1 GOTOOLCHAIN=local go build -v -o relay -ldflags="-s -w" . 2>&1
 echo "✅ Relay binary built"
 cd ..
 
-# Create logs directory
-echo "📁 Creating log directory..."
-mkdir -p logs
+# Create persistent runtime directories
+echo "📁 Creating runtime directories..."
+mkdir -p logs data
 
 # Reload Caddy (optional, requires passwordless sudo)
 echo "🔄 Reloading Caddy..."

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "wavefunc"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavefunc"
-version = "0.1.7"
+version = "0.1.8"
 description = "Decentralized Radio Platform"
 authors = ["Schlaus Kwab"]
 license = "MIT"

--- a/src-tauri/plugins/media-acquisition/android/consumer-rules.pro
+++ b/src-tauri/plugins/media-acquisition/android/consumer-rules.pro
@@ -1,1 +1,6 @@
-# Consumer rules for the WaveFunc media plugin.
+# Apache Commons Compress 1.12 registers ZIP extra-field implementations by
+# instantiating class literals through Class.newInstance(). R8 can otherwise
+# merge a registered implementation into an abstract base class, which makes
+# YoutubeDL.init crash with ExceptionInInitializerError in release builds.
+-keep class org.apache.commons.compress.archivers.zip.** { *; }
+-keepattributes InnerClasses,EnclosingMethod

--- a/src-tauri/plugins/media-acquisition/android/src/main/java/live/wavefunc/media/WavefuncMediaPlugin.kt
+++ b/src-tauri/plugins/media-acquisition/android/src/main/java/live/wavefunc/media/WavefuncMediaPlugin.kt
@@ -143,7 +143,11 @@ class WavefuncMediaPlugin(private val activity: Activity) : Plugin(activity) {
                 // the short-lived Blossom token in an external signer.
                 keepAliveForUpload = true
                 invoke.resolve(response)
-            } catch (error: Exception) {
+            } catch (error: Throwable) {
+                // Third-party Python/archive initialization can surface
+                // LinkageError (including ExceptionInInitializerError). An
+                // uncaught Error on this worker kills the whole Android app.
+                if (error is VirtualMachineError || error is ThreadDeath) throw error
                 Log.e(TAG, "Local media preparation failed", error)
                 directory.deleteRecursively()
                 val message = usefulMessage(error, "Local media download failed")
@@ -426,7 +430,7 @@ class WavefuncMediaPlugin(private val activity: Activity) : Plugin(activity) {
         }
     }
 
-    private fun usefulMessage(error: Exception, fallback: String): String {
+    private fun usefulMessage(error: Throwable, fallback: String): String {
         val details = generateSequence<Throwable>(error) { it.cause }
             .mapNotNull { it.message }
             .flatMap { it.lineSequence() }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WaveFunc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "live.wavefunc.app",
   "build": {
     "beforeDevCommand": "bun run dev:frontend",

--- a/src/components/FavoriteListCard.tsx
+++ b/src/components/FavoriteListCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useFavorites, useFavoriteStations } from "../lib/hooks/useFavorites";
 import { useSocialInteractions } from "../lib/hooks/useSocialInteractions";
 import { RadioCard } from "./RadioCard";
@@ -13,6 +13,7 @@ import {
 import { useCurrentAccount } from "../lib/nostr/auth";
 import { useWavefuncNostr } from "../lib/nostr/runtime";
 import { shareOrCopy } from "../lib/share";
+import { useStationHealth } from "../lib/nostr/hooks/useStationObservations";
 
 function formatCount(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
@@ -34,6 +35,11 @@ export function FavoriteListCard({ list, isOwner, onDeleteList }: FavoriteListCa
   const { signAndPublish } = useWavefuncNostr();
   const [isEditing, setIsEditing] = useState(false);
   const [, setShowZapDialog] = useState(false);
+  const stationAddresses = useMemo(
+    () => listStations.flatMap((station) => (station.address ? [station.address] : [])),
+    [listStations],
+  );
+  const { byAddress: healthByAddress } = useStationHealth(stationAddresses);
 
   const handleResonate = async () => {
     if (!currentUser) return;
@@ -178,7 +184,11 @@ export function FavoriteListCard({ list, isOwner, onDeleteList }: FavoriteListCa
               NO_STATIONS_LOADED
             </div>
           ) : (
-            <div className="border-t-2 border-on-background/20 max-h-[260px] overflow-y-auto scrollbar-none">
+            <div
+              className="max-h-[min(45dvh,360px)] overflow-y-scroll overscroll-contain border-t-2 border-on-background/20 [scrollbar-color:rgba(29,28,19,0.45)_transparent] [scrollbar-gutter:stable] [-webkit-overflow-scrolling:touch]"
+              aria-label={`${list.name || "Favorites"} stations`}
+              tabIndex={0}
+            >
               {listStations.map((station, i) => (
                 <div
                   key={station.id}
@@ -192,6 +202,7 @@ export function FavoriteListCard({ list, isOwner, onDeleteList }: FavoriteListCa
                       station={station}
                       variant="featured-item"
                       index={i}
+                      health={station.address ? healthByAddress.get(station.address) : undefined}
                       className={isOwner ? "border-b-0" : undefined}
                     />
                   </div>

--- a/src/components/FeaturedLists.tsx
+++ b/src/components/FeaturedLists.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useFeaturedLists } from "../lib/hooks/useFeaturedLists";
 import { useFavoriteStations } from "../lib/hooks/useFavorites";
 import { RadioCard } from "./RadioCard";
@@ -16,6 +16,7 @@ import {
   type ParsedFavoritesList,
 } from "../lib/nostr/domain";
 import { useWavefuncNostr } from "../lib/nostr/runtime";
+import { useStationHealth } from "../lib/nostr/hooks/useStationObservations";
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -31,6 +32,11 @@ function FeaturedListModule({ list, index }: { list: ParsedFavoritesList; index:
   const currentUser = useCurrentAccount();
   const { signAndPublish } = useWavefuncNostr();
   const { stations, isLoading: stationsLoading } = useFavoriteStations(list);
+  const stationAddresses = useMemo(
+    () => stations.flatMap((station) => (station.address ? [station.address] : [])),
+    [stations],
+  );
+  const { byAddress: healthByAddress } = useStationHealth(stationAddresses);
 
   const handleResonate = async () => {
     if (!currentUser) return;
@@ -90,7 +96,11 @@ function FeaturedListModule({ list, index }: { list: ParsedFavoritesList; index:
         </div>
 
         {/* Station rows */}
-        <div className="flex-grow overflow-y-auto mb-6 scrollbar-none min-h-0">
+        <div
+          className="mb-6 min-h-0 max-h-[330px] flex-grow overflow-y-scroll overscroll-contain [scrollbar-color:rgba(29,28,19,0.45)_transparent] [scrollbar-gutter:stable] [-webkit-overflow-scrolling:touch] md:max-h-none"
+          aria-label={`${list.name || "Featured collection"} stations`}
+          tabIndex={0}
+        >
           {stationsLoading && stations.length === 0 && (
             <div className="space-y-2 py-2">
               {Array.from({ length: 4 }).map((_, skeletonIndex) => (
@@ -112,6 +122,7 @@ function FeaturedListModule({ list, index }: { list: ParsedFavoritesList; index:
               station={station}
               variant="featured-item"
               index={i}
+              health={station.address ? healthByAddress.get(station.address) : undefined}
             />
           ))}
         </div>

--- a/src/components/FloatingPlayer.tsx
+++ b/src/components/FloatingPlayer.tsx
@@ -22,6 +22,8 @@ import { MobileNavigationSidebar } from "./MobileNavigationSidebar";
 import { SongFavoriteButton } from "./SongFavoriteButton";
 import { SongMagicButton } from "./SongMagicButton";
 import { useCurrentAccount } from "../lib/nostr/auth";
+import { useStationHealth } from "../lib/nostr/hooks/useStationObservations";
+import { StationHealthBadge } from "./StationHealthBadge";
 
 // ─── Snap levels ──────────────────────────────────────────────────────────────
 
@@ -135,6 +137,14 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
 
   // Metadata comes from its own store now (decoupled from playback).
   const currentMetadata = useMetadataStore((s) => s.currentMetadata);
+  const healthAddresses = useMemo(
+    () => (currentStation?.address ? [currentStation.address] : []),
+    [currentStation?.address],
+  );
+  const { byAddress: healthByAddress } = useStationHealth(healthAddresses);
+  const currentHealth = currentStation?.address
+    ? healthByAddress.get(currentStation.address)
+    : undefined;
 
   // Mirror playback state to the OS media session (lockscreen controls,
   // headset buttons, macOS Now Playing, Windows SMTC, etc). No-op in
@@ -370,14 +380,24 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
           }}
           aria-label={currentStation ? "Open station details" : "No station selected"}
         >
-          <p className={cn(
-            "text-[8px] font-bold uppercase tracking-widest leading-none",
-            state.kind === "failed" ? "text-destructive" :
-            state.kind === "reconnecting" || state.kind === "buffering" ? "text-secondary-fixed-dim" :
-            "text-primary"
-          )}>
-            {statusLabel}
-          </p>
+          <div className="flex min-w-0 items-center gap-1.5">
+            <p className={cn(
+              "truncate text-[8px] font-bold uppercase tracking-widest leading-none",
+              state.kind === "failed" ? "text-destructive" :
+              state.kind === "reconnecting" || state.kind === "buffering" ? "text-secondary-fixed-dim" :
+              "text-primary"
+            )}>
+              {statusLabel}
+            </p>
+            {currentStation && (
+              <StationHealthBadge
+                health={currentHealth}
+                compact
+                showPending
+                className="shrink-0 border shadow-none"
+              />
+            )}
+          </div>
           <h4 className="font-black text-[13px] uppercase tracking-tighter truncate font-headline leading-tight">
             {currentStation
               ? (currentStation.name || "UNKNOWN_STATION").toUpperCase().replace(/\s+/g, "_")
@@ -491,14 +511,24 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
               )}
             </div>
             <div className="flex flex-col justify-center overflow-hidden min-w-0 gap-0.5">
-              <p className={cn(
-                "font-bold uppercase text-[9px] tracking-widest leading-none",
-                state.kind === "failed" ? "text-destructive" :
-                state.kind === "reconnecting" || state.kind === "buffering" ? "text-secondary-fixed-dim" :
-                "text-primary"
-              )}>
-                {statusLabel}
-              </p>
+              <div className="flex min-w-0 items-center gap-1.5">
+                <p className={cn(
+                  "truncate font-bold uppercase text-[9px] tracking-widest leading-none",
+                  state.kind === "failed" ? "text-destructive" :
+                  state.kind === "reconnecting" || state.kind === "buffering" ? "text-secondary-fixed-dim" :
+                  "text-primary"
+                )}>
+                  {statusLabel}
+                </p>
+                {currentStation && (
+                  <StationHealthBadge
+                    health={currentHealth}
+                    compact
+                    showPending
+                    className="shrink-0 border shadow-none"
+                  />
+                )}
+              </div>
               <h4 className="font-black text-sm lg:text-base uppercase tracking-tighter truncate font-headline leading-tight">
                 {currentStation
                   ? (currentStation.name || "UNKNOWN_STATION").toUpperCase().replace(/\s+/g, "_")

--- a/src/components/GenreCarousel.tsx
+++ b/src/components/GenreCarousel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ParsedStation } from "../lib/nostr/domain";
+import type { ParsedStation, StationHealthSummary } from "../lib/nostr/domain";
 import { RadioCard } from "./RadioCard";
 import { SectionHeader } from "./SectionHeader";
 import { cn } from "@/lib/utils";
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 interface GenreCarouselProps {
   genre: string;
   stations: ParsedStation[];
+  healthByAddress?: Map<string, StationHealthSummary>;
 }
 
 /** Deterministic-ish shuffle seeded by the current hour so it changes
@@ -16,14 +17,14 @@ function shuffled<T>(arr: T[]): T[] {
   const copy = [...arr];
   for (let i = copy.length - 1; i > 0; i--) {
     const j = ((seed * (i + 1) * 2654435761) >>> 0) % (i + 1);
-    [copy[i], copy[j]] = [copy[j], copy[i]];
+    [copy[i], copy[j]] = [copy[j]!, copy[i]!];
   }
   return copy;
 }
 
 const CARD_WIDTH_PX = 220;
 
-export function GenreCarousel({ genre, stations }: GenreCarouselProps) {
+export function GenreCarousel({ genre, stations, healthByAddress }: GenreCarouselProps) {
   const shuffledStations = useMemo(
     () => shuffled(stations).slice(0, 10),
     [stations],
@@ -111,7 +112,11 @@ export function GenreCarousel({ genre, stations }: GenreCarouselProps) {
             key={station.id}
             className="shrink-0 w-[220px] md:h-[360px] snap-start flex"
           >
-            <RadioCard station={station} className="flex-1" />
+            <RadioCard
+              station={station}
+              className="flex-1"
+              health={station.address ? healthByAddress?.get(station.address) : undefined}
+            />
           </div>
         ))}
       </div>

--- a/src/components/RadioCard.tsx
+++ b/src/components/RadioCard.tsx
@@ -34,6 +34,7 @@ import {
   buildStationReactionTemplate,
   type ParsedStation,
   type Stream,
+  type StationHealthSummary,
 } from "../lib/nostr/domain";
 import {
   canPlayStreamInApp,
@@ -56,6 +57,7 @@ import { SocialCount } from "./SocialCount";
 import { Button } from "./ui/button";
 import { cn } from "@/lib/utils";
 import { useCurrentAccount } from "../lib/nostr/auth";
+import { StationHealthBadge } from "./StationHealthBadge";
 
 const MIME_TO_FORMAT: Record<string, string> = {
   "audio/mpeg": "MP3",
@@ -89,6 +91,7 @@ interface RadioCardProps {
   className?: string;
   variant?: RadioCardVariant;
   index?: number;
+  health?: StationHealthSummary;
 }
 
 export const RadioCard: React.FC<RadioCardProps> = ({
@@ -96,6 +99,7 @@ export const RadioCard: React.FC<RadioCardProps> = ({
   className,
   variant = "tile",
   index,
+  health,
 }) => {
   const { currentStation, isPlaying, playStation, pause } = usePlayerStore();
   // Read the raw state too so we can render a "failed" affordance on
@@ -394,6 +398,7 @@ export const RadioCard: React.FC<RadioCardProps> = ({
           className
         )}>
           {ownerMenu}
+          <StationHealthBadge health={health} className="absolute left-1 top-1 z-20" />
 
           {/* ── Mobile: horizontal layout (< md) ── */}
           <div className="flex md:hidden">
@@ -566,6 +571,7 @@ export const RadioCard: React.FC<RadioCardProps> = ({
           className
         )}>
           {ownerMenu}
+          <StationHealthBadge health={health} className="absolute bottom-2 left-2 z-20" />
 
           {/* Artwork + index */}
           <div className="flex-shrink-0 relative">
@@ -592,13 +598,19 @@ export const RadioCard: React.FC<RadioCardProps> = ({
               >
                 {nameDisplay}
               </h2>
-              <Link
-                to="/station/$naddr"
-                params={{ naddr: station.naddr }}
-                className="text-sm font-bold text-outline uppercase tracking-widest hover:text-secondary-fixed-dim transition-colors"
-              >
-                /STATION/{station.stationId?.toUpperCase() || "UNKNOWN"}
-              </Link>
+              {station.naddr ? (
+                <Link
+                  to="/station/$naddr"
+                  params={{ naddr: station.naddr }}
+                  className="text-sm font-bold text-outline uppercase tracking-widest hover:text-secondary-fixed-dim transition-colors"
+                >
+                  /STATION/{station.stationId?.toUpperCase() || "UNKNOWN"}
+                </Link>
+              ) : (
+                <span className="text-sm font-bold text-outline uppercase tracking-widest">
+                  /STATION/{station.stationId?.toUpperCase() || "UNKNOWN"}
+                </span>
+              )}
             </div>
             <div className="mt-auto">
               <span className="text-[10px] uppercase font-black tracking-widest text-on-surface/50 block mb-1">
@@ -763,6 +775,7 @@ export const RadioCard: React.FC<RadioCardProps> = ({
           </div>
 
           {/* Quality bar */}
+          <StationHealthBadge health={health} className="shrink-0 shadow-none" />
           <div onClick={(e) => e.stopPropagation()}>{renderQualitySelector("w-24")}</div>
         </div>
 
@@ -1097,6 +1110,7 @@ export const RadioCard: React.FC<RadioCardProps> = ({
           style={{ zIndex: Math.max(1, 30 - (index ?? 0)) }}
         >
           {ownerMenu}
+          <StationHealthBadge health={health} className="absolute left-1 top-1 z-20" />
           {mobileLayout}
           {desktopLayout}
         </div>
@@ -1113,6 +1127,7 @@ export const RadioCard: React.FC<RadioCardProps> = ({
         "group relative flex flex-col md:flex-row items-stretch bg-surface-container-low border-4 border-on-background hover:bg-secondary-fixed-dim transition-colors cursor-pointer overflow-hidden",
         className
       )}>
+        <StationHealthBadge health={health} className="absolute right-1 top-1 z-20" />
         {/* Index + thumbnail */}
         <div className="min-h-[6rem] bg-on-background text-surface flex items-center justify-center font-black text-4xl border-b-4 md:border-b-0 md:border-r-4 border-on-background px-4">
           {station.thumbnail && (

--- a/src/components/SignalCharts.tsx
+++ b/src/components/SignalCharts.tsx
@@ -1,0 +1,318 @@
+import { useMemo, useState } from "react";
+import type { Filter } from "applesauce-core/helpers/filter";
+
+import {
+  parseSongEvent,
+  SONG_KIND,
+  type ParsedSong,
+  type ParsedStation,
+  type StationRankingEntry,
+  type StationRankingMetric,
+  type StationRankingSnapshot,
+} from "../lib/nostr/domain";
+import { cn } from "../lib/utils";
+import { useStationRankings, useStationHealth } from "../lib/nostr/hooks/useStationObservations";
+import { useAppDataTimeline } from "../lib/nostr/hooks/useRelayTimeline";
+import { useStationsByAddresses } from "../lib/nostr/hooks/useStations";
+import { getDefaultSelectedStream } from "../lib/player/adapters";
+import { usePlayerStore } from "../stores/playerStore";
+import { useUIStore } from "../stores/uiStore";
+import { SectionHeader } from "./SectionHeader";
+import { CrateSaveButton } from "./CrateSaveButton";
+import { StationHealthBadge } from "./StationHealthBadge";
+
+const CHARTS: Array<{
+  metric: StationRankingMetric;
+  title: string;
+  signal: string;
+}> = [
+  { metric: "best-signal", title: "BEST_SIGNAL", signal: "VERIFIED_QUALITY" },
+  { metric: "has-now-playing", title: "HAS_NOW_PLAYING", signal: "METADATA_24H" },
+  { metric: "most-listened", title: "MOST_LISTENED", signal: "24H_SIGNAL" },
+  { metric: "most-liked", title: "MOST_LIKED", signal: "7D_RESONANCE" },
+  { metric: "most-zapped", title: "MOST_ZAPPED", signal: "7D_VOLTAGE" },
+  { metric: "on-air-now", title: "ON_AIR_NOW", signal: "LIVE_METADATA" },
+];
+
+function metricLabel(metric: StationRankingMetric, entry: StationRankingEntry) {
+  if (metric === "best-signal") return `${entry.value.toLocaleString()} SIGNAL_SCORE`;
+  if (metric === "has-now-playing") {
+    return `${entry.value.toLocaleString()} TRACKS_OBSERVED`;
+  }
+  if (metric === "most-listened") return `${entry.value.toLocaleString()} LISTENER_MIN`;
+  if (metric === "most-liked") return `${entry.value.toLocaleString()} LIKES`;
+  if (metric === "most-zapped") return `${entry.value.toLocaleString()} ZAPS`;
+  return [entry.artist, entry.title].filter(Boolean).join(" — ") || "SIGNAL_DETECTED";
+}
+
+function ChartThumbnail({ station }: { station: ParsedStation }) {
+  const [failed, setFailed] = useState(false);
+  if (station.thumbnail && !failed) {
+    return (
+      <img
+        src={station.thumbnail}
+        alt=""
+        className="size-full object-cover grayscale transition group-hover:grayscale-0"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+  return (
+    <span className="material-symbols-outlined text-2xl text-white/20">
+      radio
+    </span>
+  );
+}
+
+function ChartItem({
+  station,
+  entry,
+  metric,
+  rank,
+  health,
+}: {
+  station: ParsedStation;
+  entry: StationRankingEntry;
+  metric: StationRankingMetric;
+  rank: number;
+  health?: Parameters<typeof StationHealthBadge>[0]["health"];
+}) {
+  const playStation = usePlayerStore((state) => state.playStation);
+  const currentStation = usePlayerStore((state) => state.currentStation);
+  const isPlaying = usePlayerStore((state) => state.isPlaying);
+  const openStationSheet = useUIStore((state) => state.openStationSheet);
+  const active = currentStation?.id === station.id && isPlaying;
+
+  return (
+    <article className="group flex min-w-[250px] snap-start items-stretch border-2 border-on-background bg-surface md:min-w-0">
+      <div className="flex w-10 shrink-0 items-center justify-center bg-on-background text-sm font-black text-surface">
+        {String(rank).padStart(2, "0")}
+      </div>
+      <button
+        type="button"
+        className="flex size-16 shrink-0 items-center justify-center overflow-hidden border-r-2 border-on-background bg-[#252418]"
+        onClick={() => openStationSheet(station)}
+        title={`Open ${station.name}`}
+      >
+        <ChartThumbnail station={station} />
+      </button>
+      <button
+        type="button"
+        className="min-w-0 flex-1 px-3 py-2 text-left"
+        onClick={() => openStationSheet(station)}
+      >
+        <span className="block truncate font-headline text-xs font-black uppercase tracking-tight">
+          {(station.name || "UNKNOWN_STATION").replace(/\s+/g, "_")}
+        </span>
+        <span className="mt-0.5 block truncate text-[9px] font-black uppercase tracking-widest text-primary">
+          {metricLabel(metric, entry)}
+        </span>
+        <StationHealthBadge health={health} className="mt-1 shadow-none" />
+      </button>
+      <button
+        type="button"
+        className="w-12 shrink-0 border-l-2 border-on-background bg-primary text-white transition hover:bg-on-background"
+        onClick={() => playStation(station, getDefaultSelectedStream(station.streams))}
+        title={active ? "Playing" : "Play"}
+      >
+        <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>
+          {active ? "graphic_eq" : "play_arrow"}
+        </span>
+      </button>
+    </article>
+  );
+}
+
+function SignalChart({
+  config,
+  snapshot,
+  stations,
+  health,
+  className,
+}: {
+  config: (typeof CHARTS)[number];
+  snapshot: StationRankingSnapshot;
+  stations: Map<string, ParsedStation>;
+  health: ReturnType<typeof useStationHealth>["byAddress"];
+  className?: string;
+}) {
+  const rows = snapshot.entries
+    .map((entry) => ({ entry, station: stations.get(entry.stationAddress) }))
+    .filter((row): row is { entry: StationRankingEntry; station: ParsedStation } => Boolean(row.station))
+    .slice(0, 6);
+  if (rows.length === 0) return null;
+
+  return (
+    <section className={cn("self-start border-4 border-on-background bg-surface-container-low shadow-[6px_6px_0px_0px_rgba(29,28,19,1)]", className)}>
+      <div className="flex items-center justify-between border-b-4 border-on-background px-4 py-2">
+        <h3 className="font-headline text-base font-black uppercase tracking-tight">{config.title}</h3>
+        <span className="text-[9px] font-black uppercase tracking-widest text-primary">{config.signal}</span>
+      </div>
+      <div className="flex snap-x gap-2 overflow-x-auto p-3 scrollbar-none overscroll-x-contain md:grid md:grid-cols-1 md:overflow-visible">
+        {rows.map(({ entry, station }, index) => (
+          <ChartItem
+            key={entry.stationAddress}
+            station={station}
+            entry={entry}
+            metric={snapshot.metric}
+            rank={index + 1}
+            health={health.get(entry.stationAddress)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function DownloadThumbnail({ song }: { song: ParsedSong }) {
+  const [failed, setFailed] = useState(false);
+  const image = song.thumb || song.coverArt;
+  if (image && !failed) {
+    return (
+      <img
+        src={image}
+        alt=""
+        className="size-full object-cover"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+  return <span className="material-symbols-outlined text-2xl text-white/20">music_note</span>;
+}
+
+function RecentDownloadItem({ song, rank }: { song: ParsedSong; rank: number }) {
+  const [playerOpen, setPlayerOpen] = useState(false);
+
+  return (
+    <article className="border-2 border-on-background bg-surface">
+      <div className="group flex min-w-[250px] items-stretch md:min-w-0">
+        <div className="flex w-10 shrink-0 items-center justify-center bg-on-background text-sm font-black text-surface">
+          {String(rank).padStart(2, "0")}
+        </div>
+        <div className="flex size-16 shrink-0 items-center justify-center overflow-hidden border-r-2 border-on-background bg-[#252418]">
+          <DownloadThumbnail song={song} />
+        </div>
+        <div className="min-w-0 flex-1 px-3 py-2">
+          <span className="block truncate font-headline text-xs font-black uppercase tracking-tight">
+            {(song.title || "UNKNOWN_TRACK").replace(/\s+/g, "_")}
+          </span>
+          <span className="mt-0.5 block truncate text-[9px] font-black uppercase tracking-widest text-primary">
+            {(song.artist || "UNKNOWN_ARTIST").replace(/\s+/g, "_")}
+          </span>
+          <span className="mt-1 block text-[8px] font-black uppercase tracking-widest text-on-background/45">
+            BLOSSOM_FILE · {new Date(song.created_at * 1000).toLocaleDateString()}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-stretch border-l-2 border-on-background">
+          <CrateSaveButton song={song} size="sm" className="w-10 justify-center border-0" />
+          <button
+            type="button"
+            className="w-12 bg-primary text-white transition hover:bg-on-background"
+            onClick={() => setPlayerOpen((open) => !open)}
+            title={playerOpen ? "Close player" : `Play ${song.title || "download"}`}
+          >
+            <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>
+              {playerOpen ? "stop" : "play_arrow"}
+            </span>
+          </button>
+        </div>
+      </div>
+      {playerOpen && song.audioUrl && (
+        <div className="border-t-2 border-on-background bg-black p-2">
+          <video controls autoPlay src={song.audioUrl} className="max-h-56 w-full" />
+        </div>
+      )}
+    </article>
+  );
+}
+
+function RecentDownloadsChart({ songs, className }: { songs: ParsedSong[]; className?: string }) {
+  if (songs.length === 0) return null;
+
+  return (
+    <section className={cn("self-start border-4 border-on-background bg-surface-container-low shadow-[6px_6px_0px_0px_rgba(29,28,19,1)]", className)}>
+      <div className="flex items-center justify-between border-b-4 border-on-background px-4 py-2">
+        <h3 className="font-headline text-base font-black uppercase tracking-tight">RECENT_DOWNLOADS</h3>
+        <span className="text-[9px] font-black uppercase tracking-widest text-primary">BLOSSOM_ARCHIVE</span>
+      </div>
+      <div className="flex snap-x gap-2 overflow-x-auto p-3 scrollbar-none overscroll-x-contain md:grid md:grid-cols-1 md:overflow-visible">
+        {songs.map((song, index) => (
+          <RecentDownloadItem key={song.address || song.id} song={song} rank={index + 1} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function SignalCharts() {
+  const { rankings, isLoading } = useStationRankings();
+  const songFilters: Filter[] = useMemo(() => [{ kinds: [SONG_KIND], limit: 100 }], []);
+  const { events: songEvents, isLoading: songsLoading } = useAppDataTimeline(songFilters);
+  const recentDownloads = useMemo(() => {
+    const byAddress = new Map<string, ParsedSong>();
+    songEvents
+      .map((event) => parseSongEvent(event))
+      .filter((song) => song.audioUrl && song.youtubeId)
+      .sort((a, b) => b.created_at - a.created_at)
+      .forEach((song) => {
+        const key = song.address || song.id;
+        if (!byAddress.has(key)) byAddress.set(key, song);
+      });
+    return Array.from(byAddress.values()).slice(0, 6);
+  }, [songEvents]);
+  const addresses = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          Array.from(rankings.values()).flatMap((ranking) =>
+            ranking.entries.map((entry) => entry.stationAddress),
+          ),
+        ),
+      ),
+    [rankings],
+  );
+  const { byAddress, isLoading: stationsLoading } = useStationsByAddresses(addresses);
+  const { byAddress: health } = useStationHealth(addresses);
+  const visible = CHARTS.filter((chart) => {
+    const snapshot = rankings.get(chart.metric);
+    return snapshot?.entries.some((entry) => byAddress.has(entry.stationAddress));
+  });
+  const panelCount = visible.length + (recentDownloads.length > 0 ? 1 : 0);
+
+  if ((isLoading || stationsLoading || songsLoading) && rankings.size === 0 && recentDownloads.length === 0) {
+    return (
+      <section className="mb-16 space-y-6" aria-label="Loading signal charts">
+        <SectionHeader label="OBSERVER_FEED">SIGNAL_CHARTS</SectionHeader>
+        <div className="grid gap-6 md:grid-cols-2">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <div key={index} className="h-48 animate-pulse border-4 border-on-background bg-on-background/5" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+  if (panelCount === 0) return null;
+
+  return (
+    <section className="mb-16 space-y-6">
+      <SectionHeader label="SIGNED_NETWORK_FEED">SIGNAL_CHARTS</SectionHeader>
+      <div className="grid gap-6 md:grid-cols-2">
+        {visible.map((chart, index) => (
+          <SignalChart
+            key={chart.metric}
+            config={chart}
+            snapshot={rankings.get(chart.metric)!}
+            stations={byAddress}
+            health={health}
+            className={panelCount % 2 === 1 && index === panelCount - 1 ? "md:col-span-2" : undefined}
+          />
+        ))}
+        <RecentDownloadsChart
+          songs={recentDownloads}
+          className={panelCount % 2 === 1 ? "md:col-span-2" : undefined}
+        />
+      </div>
+      <div className="border-t-4 border-on-background/20" />
+    </section>
+  );
+}

--- a/src/components/StationDetail.tsx
+++ b/src/components/StationDetail.tsx
@@ -22,6 +22,9 @@ import {
   getDefaultSelectedStream,
   openStreamExternally,
 } from "../lib/player/adapters";
+import { useStationHealth } from "../lib/nostr/hooks/useStationObservations";
+import { StationHealthBadge } from "./StationHealthBadge";
+import { StationReportDialog } from "./StationReportDialog";
 
 interface StationDetailProps {
   station: ParsedStation;
@@ -102,6 +105,10 @@ export const StationDetail: React.FC<StationDetailProps> = ({
     selectedStream ? !canPlayStreamInApp(selectedStream) : false;
 
   const { comments, totalCount } = useComments(station.event);
+  const { byAddress: healthByAddress } = useStationHealth(
+    station.address ? [station.address] : [],
+  );
+  const health = station.address ? healthByAddress.get(station.address) : undefined;
 
   useEffect(() => {
     if (focusCommentForm && commentFormRef.current) {
@@ -185,6 +192,9 @@ export const StationDetail: React.FC<StationDetailProps> = ({
                 ON_AIR
               </div>
             )}
+            {!isCurrentlyPlaying && health && (
+              <StationHealthBadge health={health} className="absolute left-4 top-4" />
+            )}
             <button
               onClick={handlePlayClick}
               className={cn(
@@ -257,6 +267,7 @@ export const StationDetail: React.FC<StationDetailProps> = ({
                     iconSize="text-[18px]"
                   />
                 )}
+                <StationReportDialog station={station} />
               </div>
               <button
                 onClick={() => navigator.clipboard?.writeText(`${window.location.origin}/station/${station.naddr}`)}

--- a/src/components/StationHealthBadge.tsx
+++ b/src/components/StationHealthBadge.tsx
@@ -1,0 +1,56 @@
+import type { StationHealthSummary } from "../lib/nostr/domain";
+import { cn } from "../lib/utils";
+
+export function StationHealthBadge({
+  health,
+  className,
+  compact = false,
+  showPending = false,
+}: {
+  health?: StationHealthSummary;
+  className?: string;
+  compact?: boolean;
+  showPending?: boolean;
+}) {
+  if (!health && !showPending) return null;
+
+  const label = health
+    ? compact
+      ? `Q_${health.score}`
+      : `QUALITY_${health.score}`
+    : compact
+      ? "Q_—"
+      : "QUALITY_PENDING";
+  const state = health
+    ? health.insecure
+      ? "INSECURE"
+      : health.status.toUpperCase()
+    : "AWAITING_CHECK";
+  const title = health
+    ? `Quality ${health.score}/100 · ${state} · verified ${new Date(health.checkedAt * 1000).toLocaleString()}`
+    : "Station quality check pending";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 border-2 border-on-background px-1.5 py-0.5 text-[8px] font-black uppercase tracking-widest shadow-[2px_2px_0px_0px_rgba(29,28,19,1)]",
+        !health
+          ? "bg-surface-container-high text-on-background/55"
+          : health.status === "down"
+          ? "bg-primary text-white"
+          : health.status === "degraded" || health.insecure
+            ? "bg-secondary-fixed-dim text-on-background"
+            : "bg-[#a7e5c1] text-on-background",
+        className,
+      )}
+      title={title}
+      aria-label={title}
+    >
+      <span className="size-1.5 rounded-full bg-current" />
+      {label}
+      {!compact && health && (
+        <span className="border-l border-current/30 pl-1 opacity-70">{state}</span>
+      )}
+    </span>
+  );
+}

--- a/src/components/StationReportDialog.tsx
+++ b/src/components/StationReportDialog.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+
+import {
+  buildStationReportTemplate,
+  type ParsedStation,
+  type StationReportLabel,
+} from "../lib/nostr/domain";
+import { useCurrentAccount } from "../lib/nostr/auth";
+import { useWavefuncNostr } from "../lib/nostr/runtime";
+import { cn } from "../lib/utils";
+import { showToast } from "../stores/toastStore";
+import { useUIStore } from "../stores/uiStore";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+
+const LABELS: Array<{
+  value: StationReportLabel;
+  label: string;
+  tone: "positive" | "negative" | "neutral";
+}> = [
+  { value: "up", label: "WORKS", tone: "positive" },
+  { value: "adfree", label: "AD_FREE", tone: "positive" },
+  { value: "down", label: "STREAM_DOWN", tone: "negative" },
+  { value: "ads", label: "HAS_ADS", tone: "neutral" },
+  { value: "http-insecure", label: "HTTP_ONLY", tone: "neutral" },
+  { value: "metadata-wrong", label: "WRONG_METADATA", tone: "negative" },
+  { value: "duplicate", label: "DUPLICATE", tone: "negative" },
+];
+
+export function StationReportDialog({ station }: { station: ParsedStation }) {
+  const account = useCurrentAccount();
+  const { signAndPublish } = useWavefuncNostr();
+  const pulseLogin = useUIStore((state) => state.pulseLogin);
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState<StationReportLabel>("up");
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async () => {
+    if (!account || !station.address) return;
+    setSubmitting(true);
+    try {
+      await signAndPublish(
+        buildStationReportTemplate({
+          stationAddress: station.address,
+          stationPubkey: station.pubkey,
+          label,
+          note,
+        }),
+      );
+      setOpen(false);
+      setNote("");
+      showToast({
+        tone: "success",
+        title: "SIGNAL_RECORDED",
+        message: "Your signed station observation was published.",
+      });
+    } catch (error) {
+      showToast({
+        tone: "error",
+        title: "REPORT_FAILED",
+        message: error instanceof Error ? error.message : "Could not publish the report.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          if (!account) {
+            pulseLogin();
+            return;
+          }
+          setOpen(true);
+        }}
+        className={cn(
+          "flex items-center gap-1 text-on-background/45 transition-colors hover:text-primary",
+          !account && "opacity-40",
+        )}
+        title={account ? "Report or confirm station quality" : "Log in to report station quality"}
+      >
+        <span className="material-symbols-outlined text-[18px]">fact_check</span>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="rounded-none border-4 border-on-background bg-surface p-0 shadow-[8px_8px_0px_0px_rgba(29,28,19,1)]">
+          <DialogHeader className="border-b-4 border-on-background p-5 text-left">
+            <DialogTitle className="font-headline text-2xl font-black uppercase tracking-tight">
+              REPORT_SIGNAL
+            </DialogTitle>
+            <DialogDescription className="text-[10px] font-bold uppercase tracking-widest text-on-background/50">
+              Signed public evidence for {(station.name || "this station").toUpperCase()}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 p-5">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {LABELS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setLabel(option.value)}
+                  className={cn(
+                    "min-h-12 border-2 border-on-background px-2 py-2 text-[9px] font-black uppercase tracking-widest",
+                    label === option.value
+                      ? option.tone === "positive"
+                        ? "bg-[#a7e5c1]"
+                        : option.tone === "negative"
+                          ? "bg-primary text-white"
+                          : "bg-secondary-fixed-dim"
+                      : "bg-surface-container-low hover:bg-on-background hover:text-surface",
+                  )}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <label className="block">
+              <span className="mb-1 block text-[9px] font-black uppercase tracking-widest text-on-background/50">
+                OPTIONAL_NOTE
+              </span>
+              <textarea
+                value={note}
+                onChange={(event) => setNote(event.target.value.slice(0, 280))}
+                className="min-h-20 w-full resize-none border-2 border-on-background bg-surface-container-low p-3 text-sm font-bold outline-none focus:bg-surface"
+                placeholder="WHAT_DID_YOU_OBSERVE?"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={submitting}
+              className="w-full border-2 border-on-background bg-primary px-4 py-3 text-xs font-black uppercase tracking-widest text-white shadow-[3px_3px_0px_0px_rgba(29,28,19,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-none disabled:opacity-50"
+            >
+              {submitting ? "TRANSMITTING..." : "PUBLISH_OBSERVATION"}
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/StationView.tsx
+++ b/src/components/StationView.tsx
@@ -6,6 +6,7 @@ import { GenreCarousel } from "./GenreCarousel";
 import { useMemo } from "react";
 import { useFilterStore } from "../stores/filterStore";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
+import { useStationHealth } from "../lib/nostr/hooks/useStationObservations";
 
 const GENRE_SECTIONS = ["rock", "jazz", "dance", "country", "classical", "folk", "punk"];
 
@@ -68,6 +69,11 @@ export function StationView({ searchQuery }: StationViewProps) {
   );
 
   const { events: stations, eose } = useStationsObserver(filter, clientSideFilters);
+  const stationAddresses = useMemo(
+    () => stations.flatMap((station) => (station.address ? [station.address] : [])),
+    [stations],
+  );
+  const { byAddress: healthByAddress } = useStationHealth(stationAddresses);
 
   // Authoritative total (NIP-45 COUNT against the relay's bleve index).
   // The timeline subscription only loads up to 500 events, so we'd
@@ -169,7 +175,13 @@ export function StationView({ searchQuery }: StationViewProps) {
              with the brutalist staggered offset cycle. */}
           <div className="space-y-3 md:space-y-[-4px]">
             {stations.map((station, i) => (
-              <RadioCard key={station.id} station={station} variant="search-result" index={i} />
+              <RadioCard
+                key={station.id}
+                station={station}
+                variant="search-result"
+                index={i}
+                health={station.address ? healthByAddress.get(station.address) : undefined}
+              />
             ))}
           </div>
 
@@ -189,7 +201,12 @@ export function StationView({ searchQuery }: StationViewProps) {
       {!isSearching && !hasActiveFilters() && genreStations && (
         <div className="space-y-8">
           {Array.from(genreStations.entries()).map(([genre, stns]) => (
-            <GenreCarousel key={genre} genre={genre} stations={stns} />
+            <GenreCarousel
+              key={genre}
+              genre={genre}
+              stations={stns}
+              healthByAddress={healthByAddress}
+            />
           ))}
         </div>
       )}
@@ -227,7 +244,11 @@ export function StationView({ searchQuery }: StationViewProps) {
             className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4"
           >
             {stations.map((station) => (
-              <RadioCard key={station.id} station={station} />
+              <RadioCard
+                key={station.id}
+                station={station}
+                health={station.address ? healthByAddress.get(station.address) : undefined}
+              />
             ))}
           </div>
         </section>

--- a/src/config/relayPolicy.ts
+++ b/src/config/relayPolicy.ts
@@ -25,8 +25,8 @@ const WALLET_RELAYS = [
   "wss://relay.coinos.io",
 ] as const;
 
-const APP_DATA_KINDS = new Set([31237, 31337]);
-const SOCIAL_KINDS = new Set([1, 7, 1111, 9321]);
+const APP_DATA_KINDS = new Set([31237, 31238, 31239, 31240, 31337]);
+const SOCIAL_KINDS = new Set([1, 7, 1111, 1985, 9321]);
 
 function unique(relays: readonly string[]): string[] {
   return Array.from(new Set(relays.map(normalizeRelayUrl).filter(Boolean)));
@@ -108,7 +108,12 @@ function isWavefuncList(event: NostrEvent): boolean {
 
 function isWavefuncSocialEvent(event: NostrEvent): boolean {
   if (!SOCIAL_KINDS.has(event.kind)) return false;
-  if (event.kind === 7 || event.kind === 1111 || event.kind === 9321) {
+  if (
+    event.kind === 7 ||
+    event.kind === 1111 ||
+    event.kind === 1985 ||
+    event.kind === 9321
+  ) {
     return true;
   }
   return event.tags.some(

--- a/src/ctxcn/WavefuncMetadataServerClient.ts
+++ b/src/ctxcn/WavefuncMetadataServerClient.ts
@@ -13,6 +13,12 @@ export interface ExtractStreamMetadataInput {
    * The URL of the Icecast/Shoutcast stream
    */
   url: string;
+  /** Optional station address used for anonymous listening telemetry. */
+  stationAddress?: string;
+  /** Ephemeral playback session ID; never a Nostr account key. */
+  sessionId?: string;
+  /** Client observation time as Unix seconds. */
+  observedAt?: number;
 }
 
 export interface ExtractStreamMetadataOutput {
@@ -260,7 +266,7 @@ export interface DownloadAudioOutput {
 }
 
 export type WavefuncMetadataServer = {
-  ExtractStreamMetadata: (url: string) => Promise<ExtractStreamMetadataOutput>;
+  ExtractStreamMetadata: (url: string, context?: Omit<ExtractStreamMetadataInput, "url">) => Promise<ExtractStreamMetadataOutput>;
   SearchArtists: (query: string, limit?: number) => Promise<SearchArtistsOutput>;
   SearchReleases: (query: string, artist?: string, limit?: number) => Promise<SearchReleasesOutput>;
   SearchRecordings: (query: string, artist?: string, limit?: number) => Promise<SearchRecordingsOutput>;
@@ -330,7 +336,8 @@ export class WavefuncMetadataServerClient implements WavefuncMetadataServer {
       // Server returns { error: "..." } in content[0].text when isError: true
       let msg = `Tool "${name}" failed`;
       try {
-        const parsed = JSON.parse((result.content?.[0] as any)?.text ?? "{}");
+        const content = (result as { content?: Array<{ text?: string }> }).content;
+        const parsed = JSON.parse(content?.[0]?.text ?? "{}");
         if (parsed.error) msg = parsed.error;
       } catch { /* ignore parse errors */ }
       throw new Error(msg);
@@ -344,9 +351,10 @@ export class WavefuncMetadataServerClient implements WavefuncMetadataServer {
    * @returns {Promise<ExtractStreamMetadataOutput>} The result of the extract_stream_metadata operation
    */
   async ExtractStreamMetadata(
-    url: string
+    url: string,
+    context: Omit<ExtractStreamMetadataInput, "url"> = {},
   ): Promise<ExtractStreamMetadataOutput> {
-    return this.call("extract_stream_metadata", { url });
+    return this.call("extract_stream_metadata", { url, ...context });
   }
 
     /**
@@ -468,6 +476,7 @@ export function getMetadataClient(): WavefuncMetadataServerClient {
     _instance = new WavefuncMetadataServerClient({
       privateKey: config.metadataClientKey,
       relays: [config.relayUrl],
+      serverPubkey: config.metadataServerPubkey,
     });
   }
   return _instance;

--- a/src/lib/nostr/domain/index.ts
+++ b/src/lib/nostr/domain/index.ts
@@ -6,3 +6,4 @@ export * from "./shared";
 export * from "./song";
 export * from "./song-list";
 export * from "./station";
+export * from "./station-observation";

--- a/src/lib/nostr/domain/station-observation.ts
+++ b/src/lib/nostr/domain/station-observation.ts
@@ -1,0 +1,285 @@
+import type { NostrEvent } from "applesauce-core/helpers/event";
+import { z } from "zod";
+
+import type { EventTemplate } from "../types";
+import { getFirstTagValue, parseJsonContent } from "./shared";
+import { STATION_KIND } from "./station";
+
+export const STATION_HEALTH_KIND = 31238;
+export const STATION_NOW_PLAYING_KIND = 31239;
+export const STATION_RANKING_KIND = 31240;
+export const STATION_REPORT_KIND = 1985;
+export const STATION_REPORT_NAMESPACE = "wavefunc.station-status";
+
+export const StationHealthStatusSchema = z.enum([
+  "up",
+  "degraded",
+  "down",
+  "unknown",
+]);
+export type StationHealthStatus = z.infer<typeof StationHealthStatusSchema>;
+
+const StationAddressSchema = z
+  .string()
+  .refine((value) => value.startsWith(`${STATION_KIND}:`), {
+    message: "Expected a kind 31237 station address",
+  });
+
+export const StationHealthSummarySchema = z.object({
+  stationAddress: StationAddressSchema,
+  status: StationHealthStatusSchema,
+  score: z.number().min(0).max(100),
+  checkedAt: z.number().int().nonnegative(),
+  latencyMs: z.number().int().nonnegative().optional(),
+  consecutiveFailures: z.number().int().nonnegative(),
+  streamUrl: z.string().url().optional(),
+  resolvedUrl: z.string().url().optional(),
+  contentType: z.string().optional(),
+  insecure: z.boolean(),
+  evidence: z.array(z.string()).default([]),
+});
+export type StationHealthSummary = z.infer<typeof StationHealthSummarySchema>;
+
+export const StationTrackSchema = z.object({
+  stationAddress: StationAddressSchema,
+  observedAt: z.number().int().nonnegative(),
+  title: z.string().min(1).optional(),
+  artist: z.string().min(1).optional(),
+  song: z.string().min(1).optional(),
+  album: z.string().min(1).optional(),
+  mbid: z.string().min(1).optional(),
+  source: z.string().min(1).optional(),
+});
+export type StationTrack = z.infer<typeof StationTrackSchema>;
+
+export const StationRankingMetricSchema = z.enum([
+  "best-signal",
+  "has-now-playing",
+  "most-listened",
+  "most-liked",
+  "most-zapped",
+  "on-air-now",
+]);
+export type StationRankingMetric = z.infer<typeof StationRankingMetricSchema>;
+
+export const StationRankingEntrySchema = z.object({
+  stationAddress: StationAddressSchema,
+  value: z.number().nonnegative(),
+  label: z.string().optional(),
+  title: z.string().optional(),
+  artist: z.string().optional(),
+  observedAt: z.number().int().nonnegative().optional(),
+});
+export type StationRankingEntry = z.infer<typeof StationRankingEntrySchema>;
+
+export const StationRankingSnapshotSchema = z.object({
+  metric: StationRankingMetricSchema,
+  window: z.string().min(1),
+  generatedAt: z.number().int().nonnegative(),
+  entries: z.array(StationRankingEntrySchema).max(50),
+});
+export type StationRankingSnapshot = z.infer<
+  typeof StationRankingSnapshotSchema
+>;
+
+export const StationReportLabelSchema = z.enum([
+  "down",
+  "up",
+  "ads",
+  "adfree",
+  "http-insecure",
+  "metadata-wrong",
+  "duplicate",
+]);
+export type StationReportLabel = z.infer<typeof StationReportLabelSchema>;
+
+function parseAddressableContent<T>(
+  event: NostrEvent,
+  kind: number,
+  schema: z.ZodType<T>,
+): T | null {
+  if (event.kind !== kind) return null;
+  const target = getFirstTagValue(event, "a");
+  const identifier = getFirstTagValue(event, "d");
+  if (!target || identifier !== target) return null;
+  const parsed = schema.safeParse(parseJsonContent<unknown>(event.content));
+  if (!parsed.success) return null;
+  const value = parsed.data as T & { stationAddress?: string };
+  if (value.stationAddress && value.stationAddress !== target) return null;
+  return parsed.data;
+}
+
+export function parseStationHealthEvent(
+  event: NostrEvent,
+  now = Math.floor(Date.now() / 1000),
+): StationHealthSummary | null {
+  const expiration = Number(getFirstTagValue(event, "expiration"));
+  if (Number.isFinite(expiration) && expiration <= now) return null;
+  return parseAddressableContent(
+    event,
+    STATION_HEALTH_KIND,
+    StationHealthSummarySchema,
+  );
+}
+
+export function parseStationTrackEvent(
+  event: NostrEvent,
+  now = Math.floor(Date.now() / 1000),
+): StationTrack | null {
+  const expiration = Number(getFirstTagValue(event, "expiration"));
+  if (Number.isFinite(expiration) && expiration <= now) return null;
+  return parseAddressableContent(
+    event,
+    STATION_NOW_PLAYING_KIND,
+    StationTrackSchema,
+  );
+}
+
+export function parseStationRankingEvent(
+  event: NostrEvent,
+  now = Math.floor(Date.now() / 1000),
+): StationRankingSnapshot | null {
+  if (event.kind !== STATION_RANKING_KIND) return null;
+  const expiration = Number(getFirstTagValue(event, "expiration"));
+  if (Number.isFinite(expiration) && expiration <= now) return null;
+  const identifier = getFirstTagValue(event, "d");
+  const parsed = StationRankingSnapshotSchema.safeParse(
+    parseJsonContent<unknown>(event.content),
+  );
+  if (!parsed.success) return null;
+  if (`${parsed.data.metric}:${parsed.data.window}` !== identifier) return null;
+  return parsed.data;
+}
+
+export function buildStationHealthTemplate(
+  summary: StationHealthSummary,
+  expiresAt = summary.checkedAt + 36 * 60 * 60,
+): EventTemplate {
+  const value = StationHealthSummarySchema.parse(summary);
+  return {
+    kind: STATION_HEALTH_KIND,
+    content: JSON.stringify(value),
+    tags: [
+      ["d", value.stationAddress],
+      ["a", value.stationAddress],
+      ["status", value.status],
+      ["score", String(value.score)],
+      ["checked", String(value.checkedAt)],
+      ["expiration", String(expiresAt)],
+      ["t", "wavefunc"],
+    ],
+  };
+}
+
+export function buildStationTrackTemplate(
+  track: StationTrack,
+  expiresAt = track.observedAt + 3 * 60,
+): EventTemplate {
+  const value = StationTrackSchema.parse(track);
+  const tags: string[][] = [
+    ["d", value.stationAddress],
+    ["a", value.stationAddress],
+    ["expiration", String(expiresAt)],
+    ["t", "wavefunc"],
+    ["t", "tunestr"],
+  ];
+  if (value.artist) tags.push(["artist", value.artist]);
+  if (value.song ?? value.title) tags.push(["title", value.song ?? value.title!]);
+  return {
+    kind: STATION_NOW_PLAYING_KIND,
+    content: JSON.stringify(value),
+    tags,
+  };
+}
+
+export function buildStationRankingTemplate(
+  snapshot: StationRankingSnapshot,
+  expiresAt = snapshot.generatedAt + 2 * 60 * 60,
+): EventTemplate {
+  const value = StationRankingSnapshotSchema.parse(snapshot);
+  return {
+    kind: STATION_RANKING_KIND,
+    content: JSON.stringify(value),
+    tags: [
+      ["d", `${value.metric}:${value.window}`],
+      ["metric", value.metric],
+      ["window", value.window],
+      ...value.entries.map((entry) => ["a", entry.stationAddress]),
+      ["expiration", String(expiresAt)],
+      ["t", "wavefunc"],
+    ],
+  };
+}
+
+export function buildStationReportTemplate(input: {
+  stationAddress: string;
+  stationPubkey: string;
+  label: StationReportLabel;
+  note?: string;
+}): EventTemplate {
+  const stationAddress = StationAddressSchema.parse(input.stationAddress);
+  const label = StationReportLabelSchema.parse(input.label);
+  return {
+    kind: STATION_REPORT_KIND,
+    content: input.note?.trim() ?? "",
+    tags: [
+      ["L", STATION_REPORT_NAMESPACE],
+      ["l", label, STATION_REPORT_NAMESPACE],
+      ["a", stationAddress],
+      ["p", input.stationPubkey],
+      ["k", String(STATION_KIND)],
+      ["t", "wavefunc"],
+    ],
+  };
+}
+
+export function semanticTrackKey(track: Partial<StationTrack>): string | null {
+  const artist = track.artist?.trim().toLocaleLowerCase() ?? "";
+  const title = (track.song ?? track.title)?.trim().toLocaleLowerCase() ?? "";
+  if (!artist && !title) return null;
+  return `${artist}\u0000${title}`;
+}
+
+export function calculateStationHealthScore(input: {
+  reachable: boolean;
+  consecutiveFailures: number;
+  insecure: boolean;
+  reports?: Partial<Record<StationReportLabel, number>>;
+}): { score: number; status: StationHealthStatus; evidence: string[] } {
+  const evidence: string[] = [];
+  let score = input.reachable
+    ? 100
+    : Math.max(0, 55 - Math.max(0, input.consecutiveFailures - 1) * 20);
+
+  if (!input.reachable) evidence.push("scheduled-probe-failed");
+  if (input.insecure) {
+    score -= 10;
+    evidence.push("http-insecure");
+  }
+
+  const reports = input.reports ?? {};
+  const negative =
+    (reports.down ?? 0) * 4 +
+    (reports.ads ?? 0) * 2 +
+    (reports["metadata-wrong"] ?? 0) * 2;
+  const positive = (reports.up ?? 0) * 3 + (reports.adfree ?? 0);
+  const communityAdjustment = Math.max(-15, Math.min(10, positive - negative));
+  if (communityAdjustment !== 0) {
+    evidence.push(
+      communityAdjustment > 0
+        ? "community-confirmed"
+        : "community-reported",
+    );
+  }
+  score = Math.max(0, Math.min(100, score + communityAdjustment));
+
+  const status: StationHealthStatus = !input.reachable
+    ? input.consecutiveFailures >= 2
+      ? "down"
+      : "degraded"
+    : score < 70
+      ? "degraded"
+      : "up";
+
+  return { score, status, evidence };
+}

--- a/src/lib/nostr/hooks/useStationObservations.ts
+++ b/src/lib/nostr/hooks/useStationObservations.ts
@@ -1,0 +1,108 @@
+import type { Filter } from "applesauce-core/helpers/filter";
+import { useMemo } from "react";
+
+import { config } from "../../../config/env";
+import {
+  parseStationHealthEvent,
+  parseStationRankingEvent,
+  parseStationTrackEvent,
+  STATION_HEALTH_KIND,
+  STATION_NOW_PLAYING_KIND,
+  STATION_RANKING_KIND,
+  type StationHealthSummary,
+  type StationRankingMetric,
+  type StationRankingSnapshot,
+  type StationTrack,
+} from "../domain";
+import { useAppDataTimeline } from "./useRelayTimeline";
+
+function chunk<T>(values: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    result.push(values.slice(index, index + size));
+  }
+  return result;
+}
+
+export function useStationRankings() {
+  const filters = useMemo<Filter[]>(
+    () => [
+      {
+        kinds: [STATION_RANKING_KIND],
+        authors: [config.metadataServerPubkey],
+      },
+    ],
+    [],
+  );
+  const { events, isLoading, error } = useAppDataTimeline(filters);
+  const rankings = useMemo(() => {
+    const byMetric = new Map<StationRankingMetric, StationRankingSnapshot>();
+    for (const event of [...events].sort((a, b) => b.created_at - a.created_at)) {
+      if (event.pubkey !== config.metadataServerPubkey) continue;
+      const ranking = parseStationRankingEvent(event);
+      if (ranking && !byMetric.has(ranking.metric)) {
+        byMetric.set(ranking.metric, ranking);
+      }
+    }
+    return byMetric;
+  }, [events]);
+  return { rankings, isLoading, error };
+}
+
+function observationFilters(kind: number, stationAddresses: string[]): Filter[] {
+  const addresses = Array.from(new Set(stationAddresses.filter(Boolean)));
+  return chunk(addresses, 200).map((addressChunk) => ({
+    kinds: [kind],
+    authors: [config.metadataServerPubkey],
+    "#a": addressChunk,
+  }));
+}
+
+export function useStationHealth(stationAddresses: string[]) {
+  const key = JSON.stringify(stationAddresses);
+  const filters = useMemo(
+    () => observationFilters(STATION_HEALTH_KIND, stationAddresses),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [key],
+  );
+  const { events, isLoading, error } = useAppDataTimeline(
+    filters.length > 0 ? filters : null,
+  );
+  const byAddress = useMemo(() => {
+    const result = new Map<string, StationHealthSummary>();
+    for (const event of [...events].sort((a, b) => b.created_at - a.created_at)) {
+      if (event.pubkey !== config.metadataServerPubkey) continue;
+      const health = parseStationHealthEvent(event);
+      if (health && !result.has(health.stationAddress)) {
+        result.set(health.stationAddress, health);
+      }
+    }
+    return result;
+  }, [events]);
+  return { byAddress, isLoading, error };
+}
+
+export function useCurrentStationTracks(stationAddresses: string[]) {
+  const key = JSON.stringify(stationAddresses);
+  const filters = useMemo(
+    () => observationFilters(STATION_NOW_PLAYING_KIND, stationAddresses),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [key],
+  );
+  const { events, isLoading, error } = useAppDataTimeline(
+    filters.length > 0 ? filters : null,
+  );
+  const byAddress = useMemo(() => {
+    const result = new Map<string, StationTrack>();
+    const now = Math.floor(Date.now() / 1000);
+    for (const event of [...events].sort((a, b) => b.created_at - a.created_at)) {
+      if (event.pubkey !== config.metadataServerPubkey) continue;
+      const track = parseStationTrackEvent(event, now);
+      if (track && !result.has(track.stationAddress)) {
+        result.set(track.stationAddress, track);
+      }
+    }
+    return result;
+  }, [events]);
+  return { byAddress, isLoading, error };
+}

--- a/src/lib/nostr/hooks/useStations.ts
+++ b/src/lib/nostr/hooks/useStations.ts
@@ -2,7 +2,10 @@
 
 import type { Filter } from "applesauce-core/helpers/filter";
 import { useEffect, useMemo, useState } from "react";
-import { getAppDataRelayUrls } from "../../../config/nostr";
+import {
+  addressesToParameterizedFilters,
+  getAppDataRelayUrls,
+} from "../../../config/nostr";
 import {
   parseStationEvent,
   STATION_KIND,
@@ -250,4 +253,29 @@ export function useMyStations(pubkey?: string | null): UseStationStreamResult {
     [pubkey],
   );
   return useStationStream(filters);
+}
+
+export function useStationsByAddresses(addresses: string[]) {
+  const stableAddresses = useMemo(
+    () => Array.from(new Set(addresses.filter(Boolean))),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(addresses)],
+  );
+  const filters = useMemo(
+    () => addressesToParameterizedFilters(STATION_KIND, stableAddresses),
+    [stableAddresses],
+  );
+  const { events, eose } = useStationStream(
+    stableAddresses.length > 0 ? filters : [],
+  );
+  const byAddress = useMemo(
+    () =>
+      new Map(
+        events.flatMap((station) =>
+          station.address ? ([[station.address, station]] as const) : [],
+        ),
+      ),
+    [events],
+  );
+  return { stations: events, byAddress, isLoading: !eose };
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { StationView } from "../components/StationView";
 import { FeaturedLists } from "../components/FeaturedLists";
 import { useFilterStore } from "../stores/filterStore";
+import { SignalCharts } from "../components/SignalCharts";
 
 export const Route = createFileRoute("/")({
   validateSearch: (search: Record<string, unknown>) => {
@@ -23,6 +24,7 @@ function Index() {
   return (
     <>
       {showFeatured && <FeaturedLists />}
+      {showFeatured && <SignalCharts />}
       <StationView searchQuery={search || ""} />
     </>
   );

--- a/src/stores/metadataStore.ts
+++ b/src/stores/metadataStore.ts
@@ -50,6 +50,8 @@ interface MetadataStore {
   lastFetchAt: number | null;
   // Internal — don't read from UI
   _currentStreamUrl: string | null;
+  _currentStationAddress: string | null;
+  _sessionId: string | null;
   _pollTimer: ReturnType<typeof setInterval> | null;
   _reset: () => void;
 }
@@ -60,6 +62,8 @@ export const useMetadataStore = create<MetadataStore>((_set, _get) => ({
   lastError: null,
   lastFetchAt: null,
   _currentStreamUrl: null,
+  _currentStationAddress: null,
+  _sessionId: null,
   _pollTimer: null,
   _reset: () => {
     useMetadataStore.setState({
@@ -80,7 +84,17 @@ async function fetchMetadataOnce(url: string): Promise<void> {
   useMetadataStore.setState({ status: "fetching", lastError: null });
 
   try {
-    const { result: metadata } = await getMetadataClient().ExtractStreamMetadata(url);
+    const telemetry = useMetadataStore.getState();
+    const { result: metadata } = await getMetadataClient().ExtractStreamMetadata(
+      url,
+      telemetry._currentStationAddress && telemetry._sessionId
+        ? {
+            stationAddress: telemetry._currentStationAddress,
+            sessionId: telemetry._sessionId,
+            observedAt: Math.floor(Date.now() / 1000),
+          }
+        : {},
+    );
 
     // Some streams report `title` but not `song`. Unify under `song`
     // so the UI can rely on one field.
@@ -121,14 +135,22 @@ async function fetchMetadataOnce(url: string): Promise<void> {
   }
 }
 
-function startPolling(url: string): void {
+function startPolling(url: string, stationAddress: string | null): void {
   const store = useMetadataStore.getState();
-  if (store._pollTimer !== null && store._currentStreamUrl === url) {
+  if (
+    store._pollTimer !== null &&
+    store._currentStreamUrl === url &&
+    store._currentStationAddress === stationAddress
+  ) {
     return; // already polling this URL
   }
   stopPolling();
 
-  useMetadataStore.setState({ _currentStreamUrl: url });
+  useMetadataStore.setState({
+    _currentStreamUrl: url,
+    _currentStationAddress: stationAddress,
+    _sessionId: crypto.randomUUID(),
+  });
 
   // Poll immediately, then on interval.
   void fetchMetadataOnce(url);
@@ -147,6 +169,8 @@ function stopPolling(): void {
   useMetadataStore.setState({
     _pollTimer: null,
     _currentStreamUrl: null,
+    _currentStationAddress: null,
+    _sessionId: null,
   });
 }
 
@@ -181,7 +205,11 @@ export function installMetadataSubscription(): () => void {
         state.kind === "playing" || state.kind === "buffering"
           ? state.stream.url
           : null;
-      if (url) startPolling(url);
+      const stationAddress =
+        state.kind === "playing" || state.kind === "buffering"
+          ? state.station.address
+          : null;
+      if (url) startPolling(url, stationAddress);
     }
 
     // Idle means reset everything.

--- a/tests/media-acquisition-contract.test.ts
+++ b/tests/media-acquisition-contract.test.ts
@@ -59,6 +59,9 @@ describe("installed-app media acquisition contract", () => {
     const plugin = read(
       "src-tauri/plugins/media-acquisition/android/src/main/java/live/wavefunc/media/WavefuncMediaPlugin.kt",
     );
+    const consumerRules = read(
+      "src-tauri/plugins/media-acquisition/android/consumer-rules.pro",
+    );
 
     expect(build).toContain("youtubedl-android:library:0.18.1");
     expect(build).toContain("youtubedl-android:ffmpeg:0.18.1");
@@ -88,6 +91,11 @@ describe("installed-app media acquisition contract", () => {
     );
     expect(plugin).toContain("X-SHA-256");
     expect(plugin).toContain("Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING");
+    expect(plugin).toContain("catch (error: Throwable)");
+    expect(plugin).toContain("error is VirtualMachineError || error is ThreadDeath");
+    expect(consumerRules).toContain(
+      "-keep class org.apache.commons.compress.archivers.zip.** { *; }",
+    );
   });
 
   test("publishes the Android downloader license and corresponding source", () => {

--- a/tests/nostr-data-plane.test.ts
+++ b/tests/nostr-data-plane.test.ts
@@ -90,6 +90,25 @@ describe("relay policy", () => {
     );
     expect(appEventRelays).toEqual(["wss://relay.wavefunc.live"]);
 
+    const observerEventRelays = selectPublishRelays(
+      policy,
+      { ...cachedEvent, kind: 31240 },
+      ["wss://author.example"],
+    );
+    expect(observerEventRelays).toEqual(["wss://relay.wavefunc.live"]);
+
+    const reportRelays = selectPublishRelays(
+      policy,
+      {
+        ...cachedEvent,
+        kind: 1985,
+        tags: [["a", `31237:${cachedEvent.pubkey}:station-1`]],
+      },
+      ["wss://author.example"],
+    );
+    expect(reportRelays).toContain("wss://relay.wavefunc.live");
+    expect(reportRelays).toContain("wss://author.example");
+
     const fallbackRelays = selectPublishRelays(policy, {
       ...cachedEvent,
       kind: 1,

--- a/tests/station-discovery-ui.test.ts
+++ b/tests/station-discovery-ui.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("station discovery UI contracts", () => {
+  test("places every signed observer chart on the unfiltered landing page", () => {
+    const route = read("src/routes/index.tsx");
+    const charts = read("src/components/SignalCharts.tsx");
+
+    expect(route).toContain("showFeatured && <SignalCharts />");
+    expect(charts).toContain('metric: "best-signal"');
+    expect(charts).toContain('metric: "has-now-playing"');
+    expect(charts).toContain('metric: "most-listened"');
+    expect(charts).toContain('metric: "most-liked"');
+    expect(charts).toContain('metric: "most-zapped"');
+    expect(charts).toContain('metric: "on-air-now"');
+    expect(charts).toContain("if (panelCount === 0) return null");
+  });
+
+  test("surfaces quality scores on cards and in the persistent player", () => {
+    const badge = read("src/components/StationHealthBadge.tsx");
+    const player = read("src/components/FloatingPlayer.tsx");
+
+    expect(badge).toContain("`QUALITY_${health.score}`");
+    expect(badge).toContain("`Q_${health.score}`");
+    expect(player).toContain("useStationHealth(healthAddresses)");
+    expect(player).toContain("showPending");
+  });
+
+  test("adds recent user-downloaded Blossom songs to signal charts", () => {
+    const charts = read("src/components/SignalCharts.tsx");
+
+    expect(charts).toContain("RECENT_DOWNLOADS");
+    expect(charts).toContain("BLOSSOM_ARCHIVE");
+    expect(charts).toContain("song.audioUrl && song.youtubeId");
+    expect(charts).toContain("useAppDataTimeline(songFilters)");
+  });
+
+  test("keeps favorite station contents in a touch-friendly nested viewport", () => {
+    const favorites = read("src/components/FavoriteListCard.tsx");
+    const featured = read("src/components/FeaturedLists.tsx");
+
+    for (const source of [favorites, featured]) {
+      expect(source).toContain("overflow-y-scroll");
+      expect(source).toContain("overscroll-contain");
+      expect(source).toContain("scrollbar-gutter:stable");
+      expect(source).toContain("-webkit-overflow-scrolling:touch");
+      expect(source).not.toContain("overflow-y-auto scrollbar-none");
+    }
+  });
+
+  test("loads station health in batches above card rendering", () => {
+    const stationView = read("src/components/StationView.tsx");
+    const card = read("src/components/RadioCard.tsx");
+
+    expect(stationView).toContain("useStationHealth(stationAddresses)");
+    expect(card).toContain("health?: StationHealthSummary");
+    expect(card).not.toContain("useStationHealth(");
+  });
+});

--- a/tests/station-observability.test.ts
+++ b/tests/station-observability.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { NostrEvent } from "applesauce-core/helpers/event";
+
+import { ObserverDatabase } from "../contextvm/observer/database";
+import {
+  buildStationHealthTemplate,
+  buildStationRankingTemplate,
+  buildStationReportTemplate,
+  buildStationTrackTemplate,
+  calculateStationHealthScore,
+  parseStationEvent,
+  parseStationHealthEvent,
+  parseStationRankingEvent,
+  parseStationTrackEvent,
+} from "../src/lib/nostr/domain";
+
+const stationPubkey = "a".repeat(64);
+const stationAddress = `31237:${stationPubkey}:station-1`;
+
+function eventFromTemplate(
+  template: { kind: number; content: string; tags: string[][] },
+  overrides: Partial<NostrEvent> = {},
+): NostrEvent {
+  return {
+    id: "b".repeat(64),
+    pubkey: "c".repeat(64),
+    sig: "d".repeat(128),
+    created_at: 1_700_000_000,
+    ...template,
+    ...overrides,
+  };
+}
+
+function stationEvent(): NostrEvent {
+  return {
+    id: "1".repeat(64),
+    pubkey: stationPubkey,
+    sig: "2".repeat(128),
+    kind: 31237,
+    created_at: 1_700_000_000,
+    content: JSON.stringify({
+      description: "Test station",
+      streams: [
+        {
+          url: "https://radio.example/live.mp3",
+          format: "audio/mpeg",
+          quality: { bitrate: 128, codec: "mp3", sampleRate: 44100 },
+          primary: true,
+        },
+      ],
+    }),
+    tags: [
+      ["d", "station-1"],
+      ["name", "Test Station"],
+      ["description", "Test station"],
+      [
+        "stream",
+        "https://radio.example/live.mp3",
+        "audio/mpeg",
+        JSON.stringify({ bitrate: 128, codec: "mp3", sampleRate: 44100 }),
+        "primary",
+      ],
+    ],
+  };
+}
+
+describe("station observation event contracts", () => {
+  test("round-trips health, track, and ranking snapshots", () => {
+    const health = buildStationHealthTemplate({
+      stationAddress,
+      status: "up",
+      score: 95,
+      checkedAt: 1_700_000_000,
+      latencyMs: 120,
+      consecutiveFailures: 0,
+      streamUrl: "https://radio.example/live.mp3",
+      insecure: false,
+      evidence: [],
+    });
+    expect(parseStationHealthEvent(eventFromTemplate(health), 1_700_000_010)).toMatchObject({
+      stationAddress,
+      status: "up",
+      score: 95,
+    });
+    expect(parseStationHealthEvent(eventFromTemplate(health), 1_700_129_601)).toBeNull();
+
+    const track = buildStationTrackTemplate({
+      stationAddress,
+      observedAt: 1_700_000_000,
+      artist: "Artist",
+      song: "Track",
+    });
+    const trackEvent = eventFromTemplate(track);
+    expect(parseStationTrackEvent(trackEvent, 1_700_000_010)).toMatchObject({
+      artist: "Artist",
+      song: "Track",
+    });
+    expect(parseStationTrackEvent(trackEvent, 1_700_000_181)).toBeNull();
+
+    const ranking = buildStationRankingTemplate({
+      metric: "most-liked",
+      window: "7d",
+      generatedAt: 1_700_000_000,
+      entries: [{ stationAddress, value: 4 }],
+    });
+    expect(parseStationRankingEvent(eventFromTemplate(ranking), 1_700_000_010)).toMatchObject({
+      metric: "most-liked",
+      entries: [{ stationAddress, value: 4 }],
+    });
+    expect(parseStationRankingEvent(eventFromTemplate(ranking), 1_700_007_201)).toBeNull();
+  });
+
+  test("rejects mismatched targets and builds namespaced NIP-32 reports", () => {
+    const health = buildStationHealthTemplate({
+      stationAddress,
+      status: "up",
+      score: 100,
+      checkedAt: 1,
+      consecutiveFailures: 0,
+      insecure: false,
+      evidence: [],
+    });
+    const mismatched = eventFromTemplate({
+      ...health,
+      tags: health.tags.map((tag) =>
+        tag[0] === "a" ? ["a", `${stationAddress}-wrong`] : tag,
+      ),
+    });
+    expect(parseStationHealthEvent(mismatched)).toBeNull();
+
+    const report = buildStationReportTemplate({
+      stationAddress,
+      stationPubkey,
+      label: "down",
+      note: "No audio on two networks",
+    });
+    expect(report.kind).toBe(1985);
+    expect(report.tags).toContainEqual([
+      "l",
+      "down",
+      "wavefunc.station-status",
+    ]);
+    expect(report.tags).toContainEqual(["a", stationAddress]);
+  });
+
+  test("keeps community influence capped and automated reachability dominant", () => {
+    expect(
+      calculateStationHealthScore({
+        reachable: true,
+        consecutiveFailures: 0,
+        insecure: true,
+        reports: { down: 100 },
+      }),
+    ).toMatchObject({ score: 75, status: "up" });
+    expect(
+      calculateStationHealthScore({
+        reachable: false,
+        consecutiveFailures: 2,
+        reports: { up: 100 },
+        insecure: false,
+      }),
+    ).toMatchObject({ score: 45, status: "down" });
+  });
+});
+
+describe("observer aggregation database", () => {
+  const databases: ObserverDatabase[] = [];
+  afterEach(() => {
+    while (databases.length) databases.pop()?.close();
+  });
+
+  test("derives listener-minutes, unique likes, zaps, and track changes", () => {
+    const database = new ObserverDatabase(":memory:");
+    databases.push(database);
+    database.upsertStation(parseStationEvent(stationEvent()), 1_700_000_000);
+    database.completeHealthCheck({
+      stationAddress,
+      checkedAt: 1_700_000_000,
+      reachable: true,
+      status: "up",
+      score: 96,
+      streamUrl: "https://radio.example/live.mp3",
+      insecure: false,
+      evidence: ["http:200"],
+    });
+    expect(database.bestSignal(1_699_999_000, 10)[0]).toMatchObject({
+      stationAddress,
+      value: 96,
+      label: "SIGNAL_SCORE",
+    });
+    expect(database.isKnownStationStream(stationAddress, "https://radio.example/live.mp3")).toBe(true);
+    expect(database.isKnownStationStream(stationAddress, "https://attacker.example/live")).toBe(false);
+
+    const first = database.recordHeartbeat({
+      sessionId: "anonymous-session-1",
+      stationAddress,
+      streamUrl: "https://radio.example/live.mp3",
+      observedAt: 1_700_000_000,
+      metadata: { artist: "Artist", song: "Track", source: "ICY" },
+    });
+    const repeated = database.recordHeartbeat({
+      sessionId: "anonymous-session-1",
+      stationAddress,
+      streamUrl: "https://radio.example/live.mp3",
+      observedAt: 1_700_000_060,
+      metadata: { artist: "Artist", song: "Track", source: "ICY" },
+    });
+    expect(first.shouldPublishTrack).toBe(true);
+    expect(repeated.shouldPublishTrack).toBe(false);
+    expect(database.hasNowPlaying(1_699_999_000, 10)[0]).toMatchObject({
+      stationAddress,
+      value: 1,
+      label: "TRACKS_OBSERVED",
+      observedAt: 1_700_000_060,
+    });
+    expect(
+      database.mostListened(1_699_999_000, 1_700_000_060, 10)[0],
+    ).toMatchObject({ stationAddress, value: 1 });
+
+    database.recordHeartbeat({
+      sessionId: "anonymous-session-1",
+      stationAddress,
+      streamUrl: "https://radio.example/live.mp3",
+      observedAt: 1_700_003_660,
+      metadata: { artist: "Artist", song: "Track", source: "ICY" },
+    });
+    expect(
+      database.mostListened(1_699_999_000, 1_700_003_660, 10)[0],
+    ).toMatchObject({ stationAddress, value: 2 });
+
+    database.ingestSocialEvent(
+      eventFromTemplate(
+        { kind: 7, content: "+", tags: [["a", stationAddress]] },
+        { id: "3".repeat(64), pubkey: "e".repeat(64) },
+      ),
+    );
+    database.ingestSocialEvent(
+      eventFromTemplate(
+        { kind: 7, content: "+", tags: [["a", stationAddress]] },
+        { id: "4".repeat(64), pubkey: "e".repeat(64) },
+      ),
+    );
+    database.ingestSocialEvent(
+      eventFromTemplate(
+        { kind: 9735, content: "", tags: [["a", stationAddress]] },
+        { id: "5".repeat(64) },
+      ),
+    );
+    database.ingestSocialEvent(
+      eventFromTemplate(
+        { kind: 9321, content: "", tags: [["a", stationAddress]] },
+        { id: "6".repeat(64) },
+      ),
+    );
+
+    expect(database.ranking("like", 1_699_999_000, 10)[0]).toMatchObject({
+      stationAddress,
+      value: 1,
+    });
+    expect(database.ranking("zap", 1_699_999_000, 10)[0]).toMatchObject({
+      stationAddress,
+      value: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add the Nostr-native station observer, health reports, rankings, and anonymous listening telemetry
- surface quality scores in station cards and the persistent player
- add recent Blossom downloads to Signal Charts and keep favorites lists scrollable
- preserve stage-isolated relay behavior and harden Android release downloads
- bump WaveFunc to 0.1.8

## Verification
- 62 Bun tests pass
- production frontend build passes
- Rust cargo check passes
- responsive Signal Charts verified at mobile and desktop breakpoints