### PR TITLE
fix: publish downloaded songs as standalone notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-react-template",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "wavefunc"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavefunc"
-version = "0.1.8"
+version = "0.1.9"
 description = "Decentralized Radio Platform"
 authors = ["Schlaus Kwab"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WaveFunc",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "live.wavefunc.app",
   "build": {
     "beforeDevCommand": "bun run dev:frontend",

--- a/src/lib/nostr/domain/song.ts
+++ b/src/lib/nostr/domain/song.ts
@@ -174,6 +174,11 @@ export function buildShareSongNoteTemplate(
   input: ShareSongNoteInput,
 ): EventTemplate {
   const tags: string[][] = [];
+  const trimmedContent = input.content.trim();
+  const content =
+    input.audioUrl && !trimmedContent.includes(input.audioUrl)
+      ? [trimmedContent, input.audioUrl].filter(Boolean).join("\n\n")
+      : trimmedContent;
 
   for (const tag of input.hashtags ?? []) {
     tags.push(["t", tag]);
@@ -183,13 +188,9 @@ export function buildShareSongNoteTemplate(
     tags.push(["r", input.audioUrl]);
   }
 
-  if (input.song.songId && input.song.address) {
-    tags.push(["a", input.song.address]);
-  }
-
   return {
     kind: 1,
-    content: input.content,
+    content,
     tags,
   };
 }

--- a/tests/song-share-note.test.ts
+++ b/tests/song-share-note.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildShareSongNoteTemplate,
+  parseSongEvent,
+  SONG_KIND,
+} from "../src/lib/nostr/domain";
+
+const blossomUrl = "https://blossom.example/8f4d-racecar.mp4";
+
+const downloadedSong = parseSongEvent({
+  id: "a".repeat(64),
+  pubkey: "b".repeat(64),
+  kind: SONG_KIND,
+  created_at: 1_786_000_000,
+  content: "",
+  sig: "c".repeat(128),
+  tags: [
+    ["d", "racecar-by-twin-tigers"],
+    ["title", "Racecar"],
+    ["c", "Twin Tigers", "artist"],
+    ["r", blossomUrl],
+    ["i", "youtube:dQw4w9WgXcQ"],
+  ],
+});
+
+describe("downloaded song shares", () => {
+  test("publishes a standalone text note containing its caption and media link", () => {
+    const note = buildShareSongNoteTemplate({
+      song: downloadedSong,
+      content: "Saved this track with WaveFunc.",
+      audioUrl: blossomUrl,
+      hashtags: ["wavefunc", "tunestr"],
+    });
+
+    expect(note.kind).toBe(1);
+    expect(note.content).toContain("Saved this track with WaveFunc.");
+    expect(note.content).toContain(blossomUrl);
+    expect(note.tags.some((tag) => tag[0] === "e" || tag[0] === "a")).toBe(false);
+  });
+
+  test("does not duplicate a media link already present in the note text", () => {
+    const note = buildShareSongNoteTemplate({
+      song: downloadedSong,
+      content: `🎵 Racecar by Twin Tigers\n\n${blossomUrl}\n\n#wavefunc`,
+      audioUrl: blossomUrl,
+      hashtags: ["wavefunc"],
+    });
+
+    expect(note.content.match(new RegExp(blossomUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))).toHaveLength(1);
+    expect(note.tags).toContainEqual(["r", blossomUrl]);
+  });
+});


### PR DESCRIPTION
## Root cause
Song shares put the Blossom URL only in an r tag and added the kind-31337 song address as an address reference. Other Nostr clients therefore rendered the kind-1 share as a reply or annotation to an empty song container.

## Fix
- guarantee the selected Blossom URL appears in kind-1 note content
- omit address and event reply references from song-share notes
- preserve the r media tag for clients that understand it
- avoid duplicating a URL already present in the editable share text
- bump the corrected release to 0.1.9

## Verification
- 64 Bun tests pass, including cross-client event-shape regression coverage
- production frontend build passes
- Rust cargo check passes