### PR TITLE
fix: polish mobile player and signal charts

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import { rm, cp, mkdir } from "fs/promises";
 import path from "path";
 import { isLocalRelayUrl } from "./src/config/relayPolicy";
+import { defaultMetadataServerPubkey } from "./src/config/serverIdentity";
 
 if (process.argv.includes("--help") || process.argv.includes("-h")) {
   console.log(`
@@ -153,8 +154,12 @@ const result = await Bun.build({
     "process.env.APP_STAGE": JSON.stringify(appStage),
     // Only inject an explicit override; platform fallback happens at runtime.
     "process.env.RELAY_URL": definedRelayUrl,
-    // Inject metadata server configuration (defaults to devUser1 from fixtures for local builds)
-    "process.env.METADATA_SERVER_PUBKEY": JSON.stringify(process.env.METADATA_SERVER_PUBKEY || "86a82cab18b293f53cbaaae8cdcbee3f7ec427fdf9f9c933db77800bb5ef38a0"),
+    // Public observer identity has a stage-aware checked-in default so release
+    // builds remain functional even when CI provides no optional override.
+    "process.env.METADATA_SERVER_PUBKEY": JSON.stringify(
+      process.env.METADATA_SERVER_PUBKEY ||
+        defaultMetadataServerPubkey(appStage),
+    ),
     "process.env.METADATA_CLIENT_KEY": JSON.stringify(process.env.METADATA_CLIENT_KEY || "5c81bffa8303bbd7726d6a5a1170f3ee46de2addabefd6a735845166af01f5c0"),
   },
   ...cliConfig,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-react-template",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "wavefunc"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavefunc"
-version = "0.1.9"
+version = "0.1.10"
 description = "Decentralized Radio Platform"
 authors = ["Schlaus Kwab"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WaveFunc",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "live.wavefunc.app",
   "build": {
     "beforeDevCommand": "bun run dev:frontend",

--- a/src/components/FloatingPlayer.tsx
+++ b/src/components/FloatingPlayer.tsx
@@ -137,6 +137,11 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
 
   // Metadata comes from its own store now (decoupled from playback).
   const currentMetadata = useMetadataStore((s) => s.currentMetadata);
+  const hasCurrentSong = Boolean(
+    currentMetadata?.song?.trim() &&
+      currentMetadata.song !== "No metadata available",
+  );
+  const showTrackActions = isPlaying || hasCurrentSong;
   const healthAddresses = useMemo(
     () => (currentStation?.address ? [currentStation.address] : []),
     [currentStation?.address],
@@ -301,7 +306,7 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
       {/* ── Mobile station detail sheet ── */}
       <div
         className={cn(
-          "md:hidden fixed left-0 right-0 bottom-16 z-[70] bg-background border-t-4 border-on-background overflow-hidden flex flex-col",
+          "md:hidden fixed left-0 right-0 bottom-20 z-[70] bg-background border-t-4 border-on-background overflow-hidden flex flex-col",
           !stationSheetOpen && "pointer-events-none"
         )}
         style={{
@@ -358,23 +363,13 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
       </div>
 
       {/* ── Persistent mobile player ── */}
-      <div className="md:hidden fixed left-0 right-0 bottom-0 z-[90] h-16 flex items-center overflow-hidden bg-background border-t-4 border-on-background shadow-[0_-8px_0px_0px_rgba(182,0,19,1)]">
-        {/*
-          Station info uses role="button" rather than a button because the
-          favorite and magic controls are interactive descendants.
-        */}
-        <div
-          role="button"
-          tabIndex={0}
-          className="flex-1 min-w-0 px-3 py-1 text-left active:bg-surface-container-low transition-colors cursor-pointer"
+      <div className="md:hidden fixed left-0 right-0 bottom-0 z-[90] h-20 flex items-center overflow-hidden bg-background border-t-4 border-on-background shadow-[0_-8px_0px_0px_rgba(182,0,19,1)]">
+        <button
+          type="button"
+          disabled={!currentStation}
+          className="flex h-full flex-1 min-w-0 flex-col justify-center px-3 py-1.5 text-left active:bg-surface-container-low transition-colors cursor-pointer"
           onClick={() => {
             if (!currentStation) return;
-            if (stationSheetOpen) closeSheet();
-            else openStationSheet(currentStation);
-          }}
-          onKeyDown={(event) => {
-            if (!currentStation || (event.key !== "Enter" && event.key !== " ")) return;
-            event.preventDefault();
             if (stationSheetOpen) closeSheet();
             else openStationSheet(currentStation);
           }}
@@ -403,17 +398,54 @@ export function FloatingPlayer({ searchInput, setSearchInput, onSearch }: Floati
               ? (currentStation.name || "UNKNOWN_STATION").toUpperCase().replace(/\s+/g, "_")
               : "SELECT_A_STATION"}
           </h4>
-          {isPlaying && currentMetadata?.song && currentMetadata.song !== "No metadata available" && (
-            <div className="flex items-center gap-1 min-w-0">
-              <p className="text-[10px] text-on-background/55 truncate leading-none flex-1 min-w-0">
-                {currentMetadata.song}
-                {currentMetadata.artist && <span className="opacity-70"> · {currentMetadata.artist}</span>}
+          <div className="flex min-h-3 min-w-0 items-center">
+            {hasCurrentSong ? (
+              <p className="min-w-0 flex-1 truncate text-[10px] leading-none text-on-background/55">
+                {currentMetadata?.song}
+                {currentMetadata?.artist && <span className="opacity-70"> · {currentMetadata.artist}</span>}
               </p>
-              <SongFavoriteButton size="sm" className="shrink-0" />
-              <SongMagicButton size="sm" className="shrink-0" />
-            </div>
-          )}
-        </div>
+            ) : isPlaying ? (
+              <div
+                role="status"
+                aria-label="Loading now playing"
+                className="flex min-w-0 flex-1 animate-pulse items-center gap-1.5"
+              >
+                <Skeleton className="h-2.5 w-20" />
+                <Skeleton className="h-2.5 w-10 opacity-60" />
+              </div>
+            ) : null}
+          </div>
+        </button>
+
+        {showTrackActions && (
+          <div
+            role="group"
+            aria-label="Track actions"
+            className="flex h-full w-10 shrink-0 flex-col border-l-2 border-on-background/20"
+          >
+            {hasCurrentSong ? (
+              <>
+                <SongFavoriteButton
+                  size="md"
+                  className="min-h-10 min-w-10 flex-1 hover:bg-surface-variant"
+                />
+                <SongMagicButton
+                  size="md"
+                  className="min-h-10 min-w-10 flex-1 border-t-2 border-on-background/20 hover:bg-surface-variant"
+                />
+              </>
+            ) : (
+              <>
+                <div className="flex min-h-10 min-w-10 flex-1 items-center justify-center" aria-hidden="true">
+                  <Skeleton className="h-4 w-4" />
+                </div>
+                <div className="flex min-h-10 min-w-10 flex-1 items-center justify-center border-t-2 border-on-background/20" aria-hidden="true">
+                  <Skeleton className="h-4 w-4" />
+                </div>
+              </>
+            )}
+          </div>
+        )}
 
         <button
           onClick={state.kind === "failed" ? retry : isPlaying ? pause : resume}

--- a/src/components/SignalCharts.tsx
+++ b/src/components/SignalCharts.tsx
@@ -19,6 +19,7 @@ import { usePlayerStore } from "../stores/playerStore";
 import { useUIStore } from "../stores/uiStore";
 import { SectionHeader } from "./SectionHeader";
 import { CrateSaveButton } from "./CrateSaveButton";
+import { Skeleton } from "./ui/skeleton";
 import { StationHealthBadge } from "./StationHealthBadge";
 
 const CHARTS: Array<{
@@ -33,6 +34,42 @@ const CHARTS: Array<{
   { metric: "most-zapped", title: "MOST_ZAPPED", signal: "7D_VOLTAGE" },
   { metric: "on-air-now", title: "ON_AIR_NOW", signal: "LIVE_METADATA" },
 ];
+
+const CHART_PANEL_CLASS =
+  "self-start w-full min-w-0 max-w-full overflow-hidden border-4 border-on-background bg-surface-container-low shadow-[6px_6px_0px_0px_rgba(29,28,19,1)]";
+
+const CHART_RAIL_CLASS =
+  "flex min-w-0 max-w-full snap-x snap-proximity gap-2 overflow-x-scroll overscroll-x-contain p-3 scroll-px-3 scrollbar-none [touch-action:pan-x_pan-y] [-webkit-overflow-scrolling:touch] md:grid md:grid-cols-1 md:overflow-visible";
+
+const MOBILE_CHART_ITEM_CLASS =
+  "w-[min(24rem,calc(100vw-4.5rem))] shrink-0 snap-start md:w-auto md:min-w-0 md:shrink";
+
+function RankingChartSkeleton({ index }: { index: number }) {
+  return (
+    <section
+      aria-label="Loading station rankings"
+      className={cn(CHART_PANEL_CLASS, "animate-pulse")}
+    >
+      <div className="flex items-center justify-between border-b-4 border-on-background px-4 py-3">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-2 w-16" />
+      </div>
+      <div className="p-3">
+        <div className="flex h-[68px] items-stretch border-2 border-on-background bg-surface">
+          <div className="flex w-10 shrink-0 items-center justify-center bg-on-background text-sm font-black text-surface/40">
+            {String(index + 1).padStart(2, "0")}
+          </div>
+          <Skeleton className="size-16 shrink-0 rounded-none border-r-2 border-on-background" />
+          <div className="flex min-w-0 flex-1 flex-col justify-center gap-2 px-3">
+            <Skeleton className="h-3 w-3/4" />
+            <Skeleton className="h-2 w-1/2" />
+          </div>
+          <Skeleton className="w-12 shrink-0 rounded-none border-l-2 border-on-background" />
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function metricLabel(metric: StationRankingMetric, entry: StationRankingEntry) {
   if (metric === "best-signal") return `${entry.value.toLocaleString()} SIGNAL_SCORE`;
@@ -84,7 +121,7 @@ function ChartItem({
   const active = currentStation?.id === station.id && isPlaying;
 
   return (
-    <article className="group flex min-w-[250px] snap-start items-stretch border-2 border-on-background bg-surface md:min-w-0">
+    <article className={cn("group flex items-stretch border-2 border-on-background bg-surface", MOBILE_CHART_ITEM_CLASS)}>
       <div className="flex w-10 shrink-0 items-center justify-center bg-on-background text-sm font-black text-surface">
         {String(rank).padStart(2, "0")}
       </div>
@@ -143,12 +180,12 @@ function SignalChart({
   if (rows.length === 0) return null;
 
   return (
-    <section className={cn("self-start border-4 border-on-background bg-surface-container-low shadow-[6px_6px_0px_0px_rgba(29,28,19,1)]", className)}>
+    <section className={cn(CHART_PANEL_CLASS, className)}>
       <div className="flex items-center justify-between border-b-4 border-on-background px-4 py-2">
         <h3 className="font-headline text-base font-black uppercase tracking-tight">{config.title}</h3>
         <span className="text-[9px] font-black uppercase tracking-widest text-primary">{config.signal}</span>
       </div>
-      <div className="flex snap-x gap-2 overflow-x-auto p-3 scrollbar-none overscroll-x-contain md:grid md:grid-cols-1 md:overflow-visible">
+      <div className={CHART_RAIL_CLASS} aria-label={`${config.title} stations`}>
         {rows.map(({ entry, station }, index) => (
           <ChartItem
             key={entry.stationAddress}
@@ -184,8 +221,8 @@ function RecentDownloadItem({ song, rank }: { song: ParsedSong; rank: number }) 
   const [playerOpen, setPlayerOpen] = useState(false);
 
   return (
-    <article className="border-2 border-on-background bg-surface">
-      <div className="group flex min-w-[250px] items-stretch md:min-w-0">
+    <article className={cn("border-2 border-on-background bg-surface", MOBILE_CHART_ITEM_CLASS)}>
+      <div className="group flex min-w-0 items-stretch">
         <div className="flex w-10 shrink-0 items-center justify-center bg-on-background text-sm font-black text-surface">
           {String(rank).padStart(2, "0")}
         </div>
@@ -230,12 +267,12 @@ function RecentDownloadsChart({ songs, className }: { songs: ParsedSong[]; class
   if (songs.length === 0) return null;
 
   return (
-    <section className={cn("self-start border-4 border-on-background bg-surface-container-low shadow-[6px_6px_0px_0px_rgba(29,28,19,1)]", className)}>
+    <section className={cn(CHART_PANEL_CLASS, className)}>
       <div className="flex items-center justify-between border-b-4 border-on-background px-4 py-2">
         <h3 className="font-headline text-base font-black uppercase tracking-tight">RECENT_DOWNLOADS</h3>
         <span className="text-[9px] font-black uppercase tracking-widest text-primary">BLOSSOM_ARCHIVE</span>
       </div>
-      <div className="flex snap-x gap-2 overflow-x-auto p-3 scrollbar-none overscroll-x-contain md:grid md:grid-cols-1 md:overflow-visible">
+      <div className={CHART_RAIL_CLASS} aria-label="Recent downloaded songs">
         {songs.map((song, index) => (
           <RecentDownloadItem key={song.address || song.id} song={song} rank={index + 1} />
         ))}
@@ -277,26 +314,25 @@ export function SignalCharts() {
     const snapshot = rankings.get(chart.metric);
     return snapshot?.entries.some((entry) => byAddress.has(entry.stationAddress));
   });
-  const panelCount = visible.length + (recentDownloads.length > 0 ? 1 : 0);
+  const showRankingSkeletons =
+    (rankings.size === 0 && isLoading) ||
+    (rankings.size > 0 && stationsLoading && visible.length === 0);
+  const showInitialSkeletons =
+    showRankingSkeletons ||
+    (songsLoading && visible.length === 0 && recentDownloads.length === 0);
+  const skeletonCount = showInitialSkeletons ? 2 : 0;
+  const panelCount =
+    skeletonCount + visible.length + (recentDownloads.length > 0 ? 1 : 0);
 
-  if ((isLoading || stationsLoading || songsLoading) && rankings.size === 0 && recentDownloads.length === 0) {
-    return (
-      <section className="mb-16 space-y-6" aria-label="Loading signal charts">
-        <SectionHeader label="OBSERVER_FEED">SIGNAL_CHARTS</SectionHeader>
-        <div className="grid gap-6 md:grid-cols-2">
-          {Array.from({ length: 2 }).map((_, index) => (
-            <div key={index} className="h-48 animate-pulse border-4 border-on-background bg-on-background/5" />
-          ))}
-        </div>
-      </section>
-    );
-  }
   if (panelCount === 0) return null;
 
   return (
     <section className="mb-16 space-y-6">
       <SectionHeader label="SIGNED_NETWORK_FEED">SIGNAL_CHARTS</SectionHeader>
-      <div className="grid gap-6 md:grid-cols-2">
+      <div className="grid min-w-0 gap-6 md:grid-cols-2">
+        {Array.from({ length: skeletonCount }).map((_, index) => (
+          <RankingChartSkeleton key={`ranking-skeleton-${index}`} index={index} />
+        ))}
         {visible.map((chart, index) => (
           <SignalChart
             key={chart.metric}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -6,6 +6,7 @@
  */
 
 import { detectPlatform, isNativeApp } from "../lib/platform";
+import { defaultMetadataServerPubkey } from "./serverIdentity";
 
 /** Backwards-compatible name for callers that only need app-vs-web. */
 export const isTauri = isNativeApp;
@@ -117,7 +118,7 @@ export const config = {
       : "ws://localhost:3334"),
   metadataServerPubkey:
     process.env.METADATA_SERVER_PUBKEY ||
-    "86a82cab18b293f53cbaaae8cdcbee3f7ec427fdf9f9c933db77800bb5ef38a0",
+    defaultMetadataServerPubkey(getAppStage()),
   metadataClientKey:
     process.env.METADATA_CLIENT_KEY ||
     "5c81bffa8303bbd7726d6a5a1170f3ee46de2addabefd6a735845166af01f5c0",

--- a/src/config/serverIdentity.ts
+++ b/src/config/serverIdentity.ts
@@ -1,0 +1,17 @@
+import type { AppStage } from "./relayPolicy";
+
+/**
+ * Public identities are safe to bundle. Keeping them here prevents release
+ * builds without CI overrides from silently querying a different observer.
+ */
+export const PRODUCTION_METADATA_SERVER_PUBKEY =
+  "bb0707242a17a4be881919b3dcfea63f42aacedc3ff898a66be30af195ff32b2";
+
+export const DEVELOPMENT_METADATA_SERVER_PUBKEY =
+  "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+export function defaultMetadataServerPubkey(stage: AppStage): string {
+  return stage === "production"
+    ? PRODUCTION_METADATA_SERVER_PUBKEY
+    : DEVELOPMENT_METADATA_SERVER_PUBKEY;
+}

--- a/src/ctxcn/WavefuncMetadataServerClient.ts
+++ b/src/ctxcn/WavefuncMetadataServerClient.ts
@@ -278,7 +278,7 @@ export type WavefuncMetadataServer = {
 };
 
 export class WavefuncMetadataServerClient implements WavefuncMetadataServer {
-  static readonly SERVER_PUBKEY = "bb0707242a17a4be881919b3dcfea63f42aacedc3ff898a66be30af195ff32b2";
+  static readonly SERVER_PUBKEY = config.metadataServerPubkey;
   static readonly DEFAULT_RELAYS = ["ws://localhost:3334"];
   private client: Client;
   private transport: Transport;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -34,7 +34,7 @@ export const Route = createRootRoute({
           setSearchInput={setSearchInput}
           onSearch={handleSearch}
         />
-        <div className="md:pt-14 pb-16 md:pb-[100px] min-h-screen overflow-x-clip">
+        <div className="md:pt-14 pb-20 md:pb-[100px] min-h-screen overflow-x-clip">
           <div className="max-w-screen-2xl mx-auto px-4 md:px-8 py-6 min-h-[calc(100vh-7rem)]">
             <Outlet />
           </div>

--- a/tests/metadata-server-identity.test.ts
+++ b/tests/metadata-server-identity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { defaultMetadataServerPubkey } from "../src/config/serverIdentity";
+
+function read(path: string) {
+  return readFileSync(join(import.meta.dir, "..", path), "utf8");
+}
+
+describe("metadata server identity", () => {
+  test("uses the deployed observer key when a production release has no injected override", () => {
+    expect(defaultMetadataServerPubkey("production")).toBe(
+      "bb0707242a17a4be881919b3dcfea63f42aacedc3ff898a66be30af195ff32b2",
+    );
+    expect(defaultMetadataServerPubkey("development")).toBe(
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+    );
+  });
+
+  test("keeps build-time, runtime, and ContextVM client defaults on the shared identity", () => {
+    expect(read("build.ts")).toContain("defaultMetadataServerPubkey(appStage)");
+    expect(read("src/config/env.ts")).toContain(
+      "defaultMetadataServerPubkey(getAppStage())",
+    );
+    expect(read("src/ctxcn/WavefuncMetadataServerClient.ts")).toContain(
+      "static readonly SERVER_PUBKEY = config.metadataServerPubkey",
+    );
+  });
+});

--- a/tests/mobile-sheet-contract.test.ts
+++ b/tests/mobile-sheet-contract.test.ts
@@ -14,13 +14,30 @@ const store = readFileSync(
   join(import.meta.dir, "../src/stores/uiStore.ts"),
   "utf8",
 );
+const rootRoute = readFileSync(
+  join(import.meta.dir, "../src/routes/__root.tsx"),
+  "utf8",
+);
 
 describe("mobile player chrome", () => {
   test("keeps the player mounted below contextual station detail", () => {
     expect(player).toContain("Persistent mobile player");
-    expect(player).toContain("bottom-0 z-[90] h-16");
-    expect(player).toContain("bottom-16 z-[70]");
+    expect(player).toContain("bottom-0 z-[90] h-20");
+    expect(player).toContain("bottom-20 z-[70]");
+    expect(rootRoute).toContain("pb-20 md:pb-[100px]");
+    expect(player).toContain(
+      "flex h-full flex-1 min-w-0 flex-col justify-center",
+    );
+    expect(player).toContain("isPlaying && currentMetadata?.song");
     expect(player).toContain("stationSheetOpen");
+  });
+
+  test("keeps delayed now-playing feedback and track actions legible", () => {
+    expect(player).toContain('aria-label="Loading now playing"');
+    expect(player).toContain("animate-pulse");
+    expect(player).toContain('aria-label="Track actions"');
+    expect(player).toContain("flex h-full w-10 shrink-0 flex-col");
+    expect(player).toContain("min-h-10 min-w-10");
   });
 
   test("uses the station grabber to toggle size without closing it", () => {

--- a/tests/station-discovery-ui.test.ts
+++ b/tests/station-discovery-ui.test.ts
@@ -60,4 +60,22 @@ describe("station discovery UI contracts", () => {
     expect(card).toContain("health?: StationHealthSummary");
     expect(card).not.toContain("useStationHealth(");
   });
+
+  test("keeps signal chart rails viewport-bound and touch-scrollable on mobile", () => {
+    const charts = read("src/components/SignalCharts.tsx");
+
+    expect(charts).toContain("min-w-0 max-w-full");
+    expect(charts).toContain("[touch-action:pan-x_pan-y]");
+    expect(charts).toContain("[-webkit-overflow-scrolling:touch]");
+    expect(charts).toContain("w-[min(24rem,calc(100vw-4.5rem))]");
+  });
+
+  test("keeps observer skeletons visible when downloads resolve first", () => {
+    const charts = read("src/components/SignalCharts.tsx");
+
+    expect(charts).toContain("showRankingSkeletons");
+    expect(charts).toContain('aria-label="Loading station rankings"');
+    expect(charts).toContain("rankings.size === 0 && isLoading");
+    expect(charts).toContain("rankings.size > 0 && stationsLoading");
+  });
 });


### PR DESCRIPTION
## What changed

- make mobile Signal Charts viewport-bound, touch-scrollable, and snap cleanly
- keep observer skeletons visible while signed ranking data is still loading
- restore a persistent now-playing skeleton and move Favorite/Magic into a dedicated action rail
- increase the Android player height and keep the station sheet clear of it
- centralize stage-aware ContextVM/observer identities so no-secret production builds query the deployed signer
- bump WaveFunc to 0.1.10

## Why

Android/mobile chart rails were clipped and could not be swiped, delayed metadata left an empty player row, and release builds without an injected metadata pubkey queried the wrong observer signer. The public relay returned zero ranking snapshots for that fallback, leaving only Recent Downloads visible.

## Impact

Mobile users get reliable chart gestures and loading feedback, a legible now-playing player, and all signed station-ranking panels in Android, desktop, and web releases.

## Validation

- bun test: 69 passing
- production frontend build without a metadata pubkey override: passing
- cargo check for the Tauri app: passing
- 390x844 production-data preview: Best Signal, Most Liked, and Recent Downloads visible